### PR TITLE
Twinrova Boss and Blind Maiden Review

### DIFF
--- a/Sprites/Bosses/twinrova.asm
+++ b/Sprites/Bosses/twinrova.asm
@@ -422,68 +422,32 @@ Sprite_Twinrova_FireAttack:
 ; $1DBDD6 - TrinexxFire_AddFireGarnish
 AddFireGarnish:
 {
-    INC $0E80, X : LDA $0E80, X : AND.b #$07 : BNE .return
+    INC.w SprDelay, X : LDA SprDelay, X : AND.b #$07 : BNE .return
       LDA.b #$2A : JSL Sound_SetSfx2PanLong
       LDA.b #$1D : PHX : TXY : TAX : STA $00
 
   .next_slot
-    LDA $7FF800, X : BEQ .free_slot
+    LDA $7FF800, X : BEQ .free_slot ; Search for free Garnish slot
       DEX : BPL .next_slot
         DEC $0FF8 : BPL .use_search_index
           LDA $00 : STA $0FF8
-
-  .use_search_index
-    LDX $0FF8
-
+    .use_search_index
+      LDX $0FF8
   .free_slot
-    LDA.b #$10 : STA $7FF800, X : STA $0FB4
-    TYA : STA $7FF92C, X
-    
-    LDA.w SprX, Y : STA $7FF83C, X
-    LDA.w SprXH, Y : STA $7FF878, X
-    LDA.w SprY, Y : CLC : ADC.b #$10 : STA $7FF81E, X
-    LDA.w SprYH, Y : ADC.b #$00 : STA $7FF85A, X
-    
-    LDA.b #$7F : STA $7FF90E, X
-    STX $00
+    ; Set garnish ID, set garnish handled flag, set garnish parent sprite
+    LDA.b #$10 : STA $7FF800, X : STA $0FB4 : TYA : STA $7FF92C, X
+    LDA.w SprX, Y  : STA $7FF83C, X                    ; Garnish XL
+    LDA.w SprXH, Y : STA $7FF878, X                    ; Garnish XH
+    LDA.w SprY, Y  : CLC : ADC.b #$10 : STA $7FF81E, X ; Garnish YL
+    LDA.w SprYH, Y : ADC.b #$00 : STA $7FF85A, X       ; Garnish YH
+    LDA.b #$7F : STA $7FF90E, X : STX $00              ; Set garnish timer 
     PLX
 
   .return
     RTS
 }
 
-; $1DBD65 - TrinexxBreath_ice_add_ice_garnish
-AddIceGarnishV2:
-{
-    INC $0E80, X : LDA $0E80, X : AND.b #$07 : BNE .return
-      LDA.b #$14 : JSL Sound_SetSfx3PanLong
-      LDA.b #$1D : PHX : TXY : TAX : STA $00
-
-  .next_slot
-    LDA $7FF800, X : BEQ .free_slot
-      DEX : BPL .next_slot
-        DEC $0FF8 : BPL .use_search_index
-          LDA.b #$00 : STA $0FF8
-
-  .use_search_index
-    LDX $0FF8
-
-  .free_slot
-    LDA.b #$0C : STA $7FF800, X : STA $0FB4
-    TYA : STA $7FF92C, X
-    
-    LDA.w SprX, Y : STA $7FF83C, X
-    LDA.w SprXH, Y : STA $7FF878, X
-    LDA.w SprY, Y : CLC : ADC.b #$10 : STA $7FF81E, X
-    LDA.w SprYH, Y : ADC.b #$00 : STA $7FF85A, X
-    
-    LDA.b #$7F : STA $7FF90E, X : STX $00
-    
-    PLX
-
-  .return
-    RTS
-}
+; =========================================================
 
 Sprite_Twinrova_IceAttack:
 {
@@ -494,8 +458,35 @@ Sprite_Twinrova_IceAttack:
     JMP TrinexxBreath_AltEntry
 }
 
-; =========================================================
+; $1DBD65 - TrinexxBreath_ice_add_ice_garnish
+AddIceGarnishV2:
+{
+    INC.w SprDelay, X : LDA SprDelay, X : AND.b #$07 : BNE .return
+      LDA.b #$14 : JSL Sound_SetSfx3PanLong
+      LDA.b #$1D : PHX : TXY : TAX : STA $00
 
+  .next_slot
+    LDA $7FF800, X : BEQ .free_slot ; Search for free Garnish slot
+      DEX : BPL .next_slot
+        DEC $0FF8 : BPL .use_search_index
+          LDA.b #$00 : STA $0FF8
+    .use_search_index
+      LDX $0FF8
+  .free_slot
+    ; Set garnish ID, set garnish handled flag, set garnish parent sprite
+    LDA.b #$0C : STA $7FF800, X : STA $0FB4 : TYA : STA $7FF92C, X
+    LDA.w SprX, Y : STA $7FF83C, X                    ; Garnish XL
+    LDA.w SprXH, Y : STA $7FF878, X                   ; Garnish XH
+    LDA.w SprY, Y : CLC : ADC.b #$10 : STA $7FF81E, X ; Garnish YL
+    LDA.w SprYH, Y : ADC.b #$00 : STA $7FF85A, X      ; Garnish YH
+    LDA.b #$7F : STA $7FF90E, X : STX $00             ; Set garnish timer
+    PLX
+
+  .return
+    RTS
+}
+
+; =========================================================
 ; Overwrite vanilla Trinexx ice garnish
 ; Plays like a simple ice cloud animation now.
 
@@ -513,19 +504,17 @@ org $09B459
 org $09B5D6
   Garnish_SetOamPropsAndSmallSize:
 
+; SpriteData_Bump - Ice Garnish 
+org $0DB266+$CD
+  db $04
+
 org $09B33F
 TrinexxIce_Pool:
 {
   .chr
-    db $2E
-    db $2E
-    db $2C
-    db $2C
+    db $2E, $2E, $2C, $2C
   .properties
-    db $35
-    db $35
-    db $35
-    db $35
+    db $35, $35, $35, $35
 }
 
 org $09B34F
@@ -546,10 +535,6 @@ Garnish_TrinexxIce:
   JMP Garnish_SetOamPropsAndLargeSize
 }
 warnpc $09B3B8
-
-; Ice Garnish 
-org $0DB266+$CD
-  db $04
 
 pullpc
 

--- a/Sprites/Bosses/twinrova.asm
+++ b/Sprites/Bosses/twinrova.asm
@@ -885,11 +885,13 @@ SpritePrep_Blind_PrepareBattle:
 warnpc $1DA0B1
 
 ; =========================================================
+; TODO: Decide if we want to use this garnish in the fight.
+; Currently unused.
 
 org $1DA0B1
 BlindLaser_SpawnTrailGarnish:
 {
-    #_1DA0B1: LDA.w $0E80,X
+    #_1DA0B1: LDA.w SprDelay,X
     #_1DA0B4: AND.b #$00
     #_1DA0B6: BNE .exit
 

--- a/Sprites/Bosses/twinrova.asm
+++ b/Sprites/Bosses/twinrova.asm
@@ -387,6 +387,9 @@ Sprite_Twinrova_Main:
 }
 
 ; =========================================================
+; TODO: Create a new parent sprite for the Twinrova attacks
+; so that the velocity and movement aren't applied to the 
+; parent sprite itself.
 
 ; Reused function from TrinexxBreath.
 TrinexxBreath_AltEntry:

--- a/Sprites/Bosses/twinrova.asm
+++ b/Sprites/Bosses/twinrova.asm
@@ -603,8 +603,6 @@ Sprite_Twinrova_Draw:
 
     RTS
 
-
-; =========================================================
   .start_index
     db $00, $04, $08, $0C, $10, $14, $18, $1C, $22, $26, $2A, $2E
   .nbr_of_tiles
@@ -681,25 +679,19 @@ Sprite_Twinrova_Draw:
 ApplyTwinrovaGraphics:
 {
     PHX 
-
-    REP #$20             ; A = 16, XY = 8
-    LDX #$80 : STX $2100 ; turn the screen off (required)
-
+    REP #$20               ; A = 16, XY = 8
+    LDX #$80 : STX $2100   ; turn the screen off (required)
     LDX #$80 : STX $2115   ; Set the video port register every time we write it increase by 1
     LDA #$5000 : STA $2116 ; Destination of the DMA $5800 in vram <- this need to be divided by 2
     LDA #$1801 : STA $4300 ; DMA Transfer Mode and destination register 
                            ; "001 => 2 registers write once (2 bytes: p, p+1)"
     LDA.w #TwinrovaGraphics : STA $4302     ; Source address where you want gfx from ROM
     LDX.b #TwinrovaGraphics>>16 : STX $4304
-    LDA   #$2000 : STA $4305                ; size of the transfer 4 sheets of $800 each
+    LDA   #$2000 : STA $4305                ; Size of the transfer 4 sheets of $800 each
     LDX   #$01 : STX $420B                  ; Do the DMA 
-
-    LDX #$0F : STX $2100 ;turn the screen back on
-
+    LDX #$0F : STX $2100                    ; Turn the screen back on
     SEP #$30
-
     PLX
-
     RTL
 
   TwinrovaGraphics:
@@ -804,13 +796,16 @@ Follower_CheckBlindTrigger:
 }
 
 ; =========================================================
-; Called during the BlindMaiden section of Follower_BasicMover
-; to spawn Twinrova in the room. 
+; Called during Blind Maiden section of Follower_BasicMover
+; to spawn Twinrova from the Blind Maiden.
 
+; TODO: Figure out why the sprite disappears after graphics
+; are transferred in. It seems to be unrelated to the 
+; graphics code, but rather related to the BlindMaiden 
+; spawn code.
 org $1DA03C
 Blind_SpawnFromMaiden:
 {
-  ; Load the Twinrova graphics
   JSL ApplyTwinrovaGraphics
 
   LDX.b #$00 ; Load the boss into sprite index 0


### PR DESCRIPTION
Added comments and rearranging code to keep track of all planned features which need to be implemented. Here is an overview of the boss fight. 

1. Blind Maiden causes Twinrova boss to appear 
   - Still haven't decided exactly how the blind maiden should interact with the dungeon, open to ideas
   - Currently triggers when standing under the blind boss light object, however the object is not visible
   - **BUG**: Twinrova disappears when using the Blind Maiden spawning sequence. This occurs in `Blind_SpawnFromMaiden` 
3. Twinrova graphics are transferred into the game 
   - Requires lights to be turned off or transfer graphics during transition into room
4. Phase 1 of the fight has Twinrova switching between ice and fire attacks
   - Garnish attacks are based on the Trinexx fire and ice attacks
   - Currently the garnish uses twinrova as a parent sprite, causing sporadic movement. Needs a new parent sprite to control the attack movement 
   - Twinrova's movement is currently just the use of `Sprite_BounceTowardsPlayer` but it should have custom movement code 
5. Phase 2 of the fight Twinrova switches between Koume and Kotake and aggros Link. 
   - May use the blind laser garnish for additional difficulty 

Please provide feedback and/or ideas 