### PR TITLE
Prevent spike floor damage while using Jump Feather

### DIFF
--- a/Items/jump_feather.asm
+++ b/Items/jump_feather.asm
@@ -1,18 +1,15 @@
-; =============================================================================
+; =========================================================
 ; Zarby Feather 
 
 org $07AFF8 ; LinkItem_BugCatchingNet
 {
-  BIT $3A : BVS .return ;if Y or B are already pressed
-
-  LDA $6C : BNE .return ; if we are standing in a dooray or not
-
-  ; Link_CheckNewY_ButtonPress
-  JSR $B073 : BCC .return ; Check if we just pressed Y Button  
-  JSL NewBookCode
-
-.return
-  RTS
+    BIT $3A : BVS .return ;if Y or B are already pressed
+      LDA $6C : BNE .return ; if we are standing in a dooray or not
+        ; Link_CheckNewY_ButtonPress
+        JSR $B073 : BCC .return ; Check if we just pressed Y Button  
+          JSL LinkItem_JumpFeather
+  .return
+    RTS
 }
 
 ; =============================================================================

--- a/Items/jump_feather.asm
+++ b/Items/jump_feather.asm
@@ -12,7 +12,20 @@ org $07AFF8 ; LinkItem_BugCatchingNet
     RTS
 }
 
-; =============================================================================
+; =========================================================
+; Prevent Link from taking damage while jumping spikes
+; The game originally differentiates between your armor 
+; for the damage take, however the table has all the same
+; values, so it's effectively useless. 
+
+; TileDetect_MainHandler_no_moon_pearl
+; org $07D23D
+org $07D242
+  JSL CheckIfJumpingForSpikeDamage
+  NOP #2
+warnpc $07D248
+
+; =========================================================
 
 org $2B8000
 LinkItem_JumpFeather:
@@ -57,6 +70,26 @@ LinkItem_JumpFeather:
     
   .cantuseit
     RTL
+}
+
+; =========================================================
+; Y contains our armor value
+; Currently requires a very close jump and will still
+; damage the player midair if you jump from too far away.
+
+CheckIfJumpingForSpikeDamage:
+{
+    PHB : PHK : PLB
+    LDA $29 : BNE .airborne
+      LDA.w .spike_floor_damage, Y : STA.w $0373
+  .airborne
+    PLB
+    RTL
+
+  .spike_floor_damage
+    db $08 ; green
+    db $08 ; blue
+    db $04 ; red
 }
 
 print  "End of Items/jump_feather.asm     ", pc

--- a/Items/jump_feather.asm
+++ b/Items/jump_feather.asm
@@ -15,49 +15,48 @@ org $07AFF8 ; LinkItem_BugCatchingNet
 ; =============================================================================
 
 org $2B8000
-NewBookCode:
+LinkItem_JumpFeather:
 {
   JSL $07983A ; Reset swim state
   LDA $46 : BNE .cantuseit
-  LDA #$02 : STA $5D ; state recoil
-  LDA #$01 : STA $4D ; state recoil 2
+    LDA #$02 : STA $5D ; set link state recoil
+    LDA #$02 : STA $4D ; set jumping state (ledge hop)
 
-  ; Length of the jump
-  LDA #$20 
+    ; Length of the jump
+    LDA #$20 : STA $46 
 
-  STA $46 
+    ; Height of the jump
+    LDA #$24 
 
-  ; Height of the jump
-  LDA #$24 
+    ; Set vertical resistance 
+    STA $29
+    STA $02C7
 
-  ; Set vertical resistance 
-  STA $29
-  STA $02C7
-  ; Set Links direction to right(?)
-  LDA #$08 : STA $0340 : STA $67
+    ; Set Links direction to right(?)
+    LDA #$08 : STA $0340 : STA $67
 
-  ; Reset Link movement offsets 
-  STZ $31
-  STZ $30
+    ; Reset Link movement offsets 
+    STZ $31 : STZ $30
 
-  LDA $F4 : AND #$08 : BEQ .noUp
-      LDA #-8 ; Change that -8 if you want higher speed moving up
-      STA $27 ; Vertical recoil
-  .noUp
-  LDA $F4 : AND #$04 : BEQ .noDown
-      LDA #8  ; Change that -8 if you want higher speed moving down
-      STA $27
-  .noDown
-  LDA $F4 : AND #$02 : BEQ .noLeft
-      LDA #-8 ; Change that -8 if you want higher speed moving left
-      STA $28 ; Horizontal recoil
-  .noLeft
-  LDA $F4 : AND #$01 : BEQ .noRight
-      LDA #8  ; Change that 8 if you want higher speed moving right
-      STA $28
-  .noRight
+      LDA $F4 : AND #$08 : BEQ .noUp
+        LDA #-8 ; Change that -8 if you want higher speed moving up
+        STA $27 ; Vertical recoil
+    .noUp
+      LDA $F4 : AND #$04 : BEQ .noDown
+        LDA #8  ; Change that -8 if you want higher speed moving down
+        STA $27
+    .noDown
+      LDA $F4 : AND #$02 : BEQ .noLeft
+        LDA #-8 ; Change that -8 if you want higher speed moving left
+        STA $28 ; Horizontal recoil
+    .noLeft
+      LDA $F4 : AND #$01 : BEQ .noRight
+        LDA #8  ; Change that 8 if you want higher speed moving right
+        STA $28
+    .noRight
+    
   .cantuseit
-  RTL
+    RTL
 }
 
 print  "End of Items/jump_feather.asm     ", pc


### PR DESCRIPTION
This PR makes updates to the jump feather code and adds an additional hook inside of bank 07 `TileDetect_MainHandler` which prevents Link from taking damage while jumping over floor spikes by checking the wram value $29 which represents his Z recoil. This currently is a crude approach which requires a very close and precise jump, and if jumped at from too far away the player will still take damage while appearing in mid air. It might be better to use a different value, like Links absolute Z position for this. 

Additionally, I found that the spike floor code actually differentiates based on the armor value you are wearing, but in the vanilla game all three armor values hit for the same damage (1 heart) so I've recreated this table in free space and assigned a lesser value to the best armor. 

And a small change I made in the jump feather code itself was changing the jumping wram value $4D from 01 (the recoil "oh shit" animation) to 02 which is the ledge hop animation. It's a bit inconsistent as Links feet arent always facing outward and sometimes he is just standing in place while jumping, but the eventual goal is to make a custom jumping animation so I feel like this is fine for now. 