### PR TITLE
fix(build): harden hook tool paths

### DIFF
--- a/Scripts/Generate/generate_hooks_json.py
+++ b/Scripts/Generate/generate_hooks_json.py
@@ -626,7 +626,9 @@ def main() -> int:
     hooks = scan_hooks(root)
 
     rom_meta = {}
-    rom_path = (root / args.rom).resolve() if not args.rom.is_absolute() else args.rom
+    rom_path = (
+        root / args.rom if not args.rom.is_absolute() else args.rom
+    ).resolve()
     if rom_path.exists():
         rom_meta['path'] = str(rom_path.relative_to(root))
         try:

--- a/Tests/unit/test_hook_tool_paths.py
+++ b/Tests/unit/test_hook_tool_paths.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from Scripts.Validate.verify_hooks_json import _run_generator
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK_GENERATOR = REPO_ROOT / "Scripts" / "Generate" / "generate_hooks_json.py"
+
+
+class HookToolPathTest(unittest.TestCase):
+    def test_verifier_uses_categorized_generator_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            generator = root / "Scripts" / "Generate" / "generate_hooks_json.py"
+            generator.parent.mkdir(parents=True)
+            generator.write_text(
+                textwrap.dedent(
+                    """\
+                    import argparse
+                    import json
+
+                    parser = argparse.ArgumentParser()
+                    parser.add_argument("--root")
+                    parser.add_argument("--output")
+                    parser.add_argument("--rom")
+                    args = parser.parse_args()
+                    with open(args.output, "w", encoding="utf-8") as handle:
+                        json.dump({"hooks": []}, handle)
+                    """
+                ),
+                encoding="utf-8",
+            )
+            output = root / "generated.json"
+
+            _run_generator(root, root / "rom.sfc", output)
+
+            self.assertEqual(
+                json.loads(output.read_text(encoding="utf-8")), {"hooks": []}
+            )
+            self.assertFalse((root / "scripts" / "generate_hooks_json.py").exists())
+
+    def test_generator_canonicalizes_absolute_rom_path_before_relativizing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            temp_root = Path(tmp)
+            real_root = temp_root / "real"
+            alias_root = temp_root / "alias"
+            rom = real_root / "Roms" / "test.sfc"
+            rom.parent.mkdir(parents=True)
+            rom.write_bytes(b"test-rom")
+            (real_root / "test.asm").write_text("org $008000\nnop\n", encoding="utf-8")
+
+            try:
+                os.symlink(real_root, alias_root, target_is_directory=True)
+            except (OSError, NotImplementedError) as exc:
+                self.skipTest(f"directory symlinks unavailable: {exc}")
+
+            output = temp_root / "hooks.json"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(HOOK_GENERATOR),
+                    "--root",
+                    str(alias_root),
+                    "--rom",
+                    str(alias_root / "Roms" / "test.sfc"),
+                    "--output",
+                    str(output),
+                ],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            metadata = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(metadata["rom"]["path"], "Roms/test.sfc")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- canonicalize an absolute `--rom` path before deriving project-relative hook metadata
- preserve the portable metadata value `Roms/oos168x.sfc` when macOS aliases the same checkout as `/tmp/...` and `/private/tmp/...`
- add focused coverage that locks the categorized `Scripts/Generate/generate_hooks_json.py` verifier path and the path-alias behavior

## Root cause

`generate_hooks_json.py` resolved `--root` but did not resolve an already-absolute `--rom`. On macOS, the disposable Oracle pipeline therefore compared a `/tmp/...` ROM against a `/private/tmp/...` root with `Path.relative_to()`, even though both names referred to the same project. Hook generation failed with `ValueError`.

The stale lowercase verifier lookup is already repaired by base PR #107 in commit `6ef4cdb`; this PR adds regression coverage so that categorized path cannot silently regress.

## Verification

- `python3 -m unittest discover -s Tests/unit -v` — 39 passed
- `python3 Scripts/Analysis/lint_docs.py` — passed
- independent strict review: no blockers; focused 2/2 tests and real/alias/external path matrix passed
- replayed the exact disposable fixture shape using root `/private/tmp/oos-pr72-pipeline.bcWhSy/oracle-of-secrets` and ROM `/tmp/oos-pr72-pipeline.bcWhSy/oracle-of-secrets/Roms/oos168x.sfc` — generated 632 hooks and serialized `Roms/oos168x.sfc`
- no canonical ROM was written; tests use synthetic files and the replay only read the disposable fixture
- exact-head ROM Tests: [run 29463197659](https://github.com/scawful/Oracle-of-Secrets/actions/runs/29463197659) passed ASM, Lua, Python/metadata, and summary checks on `9afd8692`; emulator job skipped as designed

## Dependency

Stacked on #107 because that PR contains the Scripts relocation and categorized verifier-path repair. Merge #107 first, then retarget this PR to `master`.



