### PR TITLE
test(build): guard D4 water-table completeness

### DIFF
--- a/Docs/Debugging/Issues/WaterCollision_Handoff.md
+++ b/Docs/Debugging/Issues/WaterCollision_Handoff.md
@@ -21,7 +21,8 @@ Applied data-driven fixes for active Zora Baby + water gate regressions:
 - `Scripts/Generate/generate_water_gate_runtime_tables.py` (new)
   - Extracts room overlay object streams (default object ids `0xC9,0xD9`) and Zora Baby switch targets from ROM room data.
 - `Scripts/Build/build_rom.sh`
-  - Auto-runs table generation before assembly, preferring `Oracle-of-Secrets.yaze` `rom_filename` as source ROM.
+  - Normal builds assemble the tracked generated tables as release source.
+  - Table refresh is explicit and transactional via `OOS_REFRESH_WATER_TABLES=1` plus an authoring ROM.
 
 Runtime expectations to verify:
 
@@ -45,10 +46,13 @@ Use these room-data controls to drive runtime behavior without hand-editing ASM:
 - Water fill collision zones (switch-activated):
   - Paint custom collision tile `0xF5` in the room where water should become swimmable after switch activation.
   - `CustomRoomCollision` now treats `0xF5` as an authoring marker and does **not** apply it during normal room load.
-  - Build regenerates `Dungeons/generated/water_fill_table.asm` (ROM `$25:E000`) from those marker offsets.
+  - An explicit refresh regenerates `Dungeons/generated/water_fill_table.asm` (ROM `$25:E000`) from those marker offsets.
   - At water fill completion, runtime writes deep-water collision (`0x08`) to those offsets.
   - Preset-driven CLI workflow (recommended):
-    - `python3 Scripts/Generate/water_fill_author.py --rom Roms/oos168.sfc --preset zora_d4 --write`
+    - Author only on the trusted editable base ROM or a disposable scratch copy, never `Roms/oos168x.sfc`.
+    - `python3 Scripts/Generate/water_fill_author.py --rom <authoring-rom> --preset zora_d4 --write`
+    - `OOS_REFRESH_WATER_TABLES=1 OOS_WATER_FILL_TABLE_ROM=<authoring-rom> ./Scripts/Build/build_rom.sh 168`
+    - Refresh fails unless both required rooms (`0x25`, `0x27`) still contain marker tiles. The two generated water-table includes are promoted together only after a successful rebuild.
     - Presets:
       - `room25_lower_band` (lower-half drain band)
       - `room27_upside_t` (dam upside-T with right-side stair gap)
@@ -116,7 +120,10 @@ Room entry re-applies collision if the bit is set.
 
 - Script: `python3 Scripts/Generate/generate_water_gate_runtime_tables.py --rom <rom>`
 - Script: `python3 Scripts/Generate/generate_water_fill_table.py --rom <rom>`
-- Auto-run during build (`Scripts/Build/build_rom.sh`) unless `OOS_SKIP_WATER_TABLE_GEN=1`.
+- Normal builds use the tracked generated includes. This keeps repeated builds stable even though patched build output does not retain every `0xF5` authoring marker.
+- Refresh both includes explicitly with:
+  - `OOS_REFRESH_WATER_TABLES=1 OOS_WATER_FILL_TABLE_ROM=<authoring-rom> ./Scripts/Build/build_rom.sh 168`
+- The refresh is transactional and requires marker data for rooms `0x25` and `0x27`; a failed generation or rebuild restores the previous include pair and patched ROM.
 - Outputs:
   - `WaterOverlayRoomTable` / `WaterOverlayData_*` (from object ids `0xC9,0xD9` by default)
   - `ZoraBabySwitchTargetTable` (marker priority default: `0x124,0x137,0x135`)

--- a/Docs/Debugging/Issues/WaterCollision_Handoff.md
+++ b/Docs/Debugging/Issues/WaterCollision_Handoff.md
@@ -34,15 +34,20 @@ Runtime expectations to verify:
 
 Use these room-data controls to drive runtime behavior without hand-editing ASM:
 
+Normal builds consume the tracked `Dungeons/generated/water_gate_runtime_tables.asm`
+and `Dungeons/generated/water_fill_table.asm` release sources. Only an explicit,
+transactional water-table refresh regenerates both includes from the selected
+authoring ROM.
+
 - Water drain/gate overlay segments:
   - Place water overlay objects in the room (`0x0C9` flood and/or `0x0D9` swim-mask forms).
-  - Build regenerates `WaterOverlayRoomTable` automatically.
+  - An explicit refresh regenerates `WaterOverlayRoomTable`.
 - Zora Baby post-switch walk target:
   - Place one marker object near the desired destination using ids in priority order:
     - `0x0124` (preferred)
     - `0x0137`
     - `0x0135`
-  - Build regenerates `ZoraBabySwitchTargetTable`; baby picks the nearest marker at runtime.
+  - An explicit refresh regenerates `ZoraBabySwitchTargetTable`; baby picks the nearest marker at runtime.
 - Water fill collision zones (switch-activated):
   - Paint custom collision tile `0xF5` in the room where water should become swimmable after switch activation.
   - `CustomRoomCollision` now treats `0xF5` as an authoring marker and does **not** apply it during normal room load.

--- a/Docs/Planning/Plans/development_workflow_alignment_2026-03-28.md
+++ b/Docs/Planning/Plans/development_workflow_alignment_2026-03-28.md
@@ -36,7 +36,8 @@ before large new feature pushes.
 
 - `Scripts/Build/build_rom.sh` now does more than assembly:
   - menu validation
-  - water table generation
+  - tracked water-table consumption on normal builds; generation only during an
+    explicit opt-in refresh
   - `check_zscream_overlap.py`
   - hooks.json regeneration
   - optional sprite/hook validation

--- a/Scripts/Build/build_rom.sh
+++ b/Scripts/Build/build_rom.sh
@@ -97,6 +97,7 @@ water_restore_pending=0
 water_fill_backup=""
 water_runtime_backup=""
 water_patched_backup=""
+water_patched_existed=0
 restore_flags() {
   if [[ "$flags_modified" != "1" ]]; then
     return 0
@@ -120,10 +121,12 @@ restore_water_transaction() {
   fi
   cp -f "$water_fill_backup" "$repo_root/Dungeons/generated/water_fill_table.asm"
   cp -f "$water_runtime_backup" "$repo_root/Dungeons/generated/water_gate_runtime_tables.asm"
-  if [[ -n "$water_patched_backup" && -f "$water_patched_backup" ]]; then
+  if [[ "$water_patched_existed" == "1" ]]; then
     cp -f "$water_patched_backup" "$patched_rom"
+  else
+    rm -f "$patched_rom"
   fi
-  echo "[*] Restored water includes after failed refresh." >&2
+  echo "[*] Restored water includes and patched ROM after failed refresh." >&2
 }
 cleanup() {
   restore_water_transaction
@@ -350,7 +353,6 @@ for required_room in 25 27; do
     exit 1
   fi
 done
-assemble_rom
 
 water_refresh_requested="${OOS_REFRESH_WATER_TABLES:-0}"
 if [[ -n "${OOS_WATER_FILL_TABLE_ROM:-}" || -n "${OOS_WATER_TABLE_ROM:-}" ]]; then
@@ -373,7 +375,25 @@ if [[ "$water_refresh_requested" == "1" ]]; then
     exit 1
   fi
 
+  # Arm rollback before assemble_rom mutates the patched output. Every explicit
+  # refresh is one transaction spanning initial assembly, candidate generation,
+  # staged-table rebuild, and all later build checks.
   water_tmp_dir="$(mktemp -d "$rom_dir/.water_tables.XXXXXX")"
+  water_fill_backup="$water_tmp_dir/water_fill_table.original.asm"
+  water_runtime_backup="$water_tmp_dir/water_gate_runtime_tables.original.asm"
+  water_patched_backup="$water_tmp_dir/patched_rom.original.sfc"
+  cp -f "$repo_root/Dungeons/generated/water_fill_table.asm" "$water_fill_backup"
+  cp -f "$repo_root/Dungeons/generated/water_gate_runtime_tables.asm" "$water_runtime_backup"
+  if [[ -f "$patched_rom" ]]; then
+    cp -f "$patched_rom" "$water_patched_backup"
+    water_patched_existed=1
+  fi
+  water_restore_pending=1
+fi
+
+assemble_rom
+
+if [[ "$water_refresh_requested" == "1" ]]; then
   candidate_dir="$water_tmp_dir/candidate"
   generate_water_tables "$water_table_rom" "$candidate_dir"
 
@@ -386,14 +406,6 @@ if [[ "$water_refresh_requested" == "1" ]]; then
   fi
 
   if [[ "$water_tables_changed" == "1" ]]; then
-    water_fill_backup="$water_tmp_dir/water_fill_table.original.asm"
-    water_runtime_backup="$water_tmp_dir/water_gate_runtime_tables.original.asm"
-    water_patched_backup="$water_tmp_dir/patched_rom.original.sfc"
-    cp -f "$repo_root/Dungeons/generated/water_fill_table.asm" "$water_fill_backup"
-    cp -f "$repo_root/Dungeons/generated/water_gate_runtime_tables.asm" "$water_runtime_backup"
-    cp -f "$patched_rom" "$water_patched_backup"
-    water_restore_pending=1
-
     cp -f "$candidate_dir/water_fill_table.asm" "$repo_root/Dungeons/generated/water_fill_table.asm"
     cp -f "$candidate_dir/water_gate_runtime_tables.asm" "$repo_root/Dungeons/generated/water_gate_runtime_tables.asm"
     echo "[*] Water table candidates staged; rebuilding once from the base ROM..."

--- a/Tests/unit/test_water_fill_build_transaction.py
+++ b/Tests/unit/test_water_fill_build_transaction.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from Scripts.Generate import generate_water_fill_table as water_fill
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROM_SIZE = 0x130000
+
+
+def pc_to_lorom(pc: int) -> int:
+    bank = (pc >> 15) & 0x7F
+    address = (pc & 0x7FFF) | 0x8000
+    return (bank << 16) | address
+
+
+def make_authoring_rom(path: Path, rooms: tuple[int, ...]) -> None:
+    data = bytearray(ROM_SIZE)
+    pointer_table = water_fill.snes_to_pc(water_fill.ROOM_POINTER_SNES)
+    for index, room_id in enumerate(rooms):
+        stream_pc = water_fill.CUSTOM_COLLISION_DATA_PC_START + (index * 0x10)
+        pointer_pc = pointer_table + (room_id * 3)
+        data[pointer_pc : pointer_pc + 3] = pc_to_lorom(stream_pc).to_bytes(
+            3, "little"
+        )
+        data[stream_pc : stream_pc + 7] = bytes(
+            (0xF0, 0xF0, room_id, 0x01, 0xF5, 0xFF, 0xFF)
+        )
+    path.write_bytes(data)
+
+
+def copy_repo_file(source_root: Path, target_root: Path, relative: str) -> None:
+    source = source_root / relative
+    target = target_root / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target)
+
+
+class WaterFillBuildTransactionTest(unittest.TestCase):
+    def prepare_fixture(self, root: Path) -> tuple[Path, Path]:
+        repo = root / "oracle-of-secrets"
+        repo.mkdir()
+
+        for relative in (
+            "Scripts/Build/build_rom.sh",
+            "Scripts/Generate/generate_water_fill_table.py",
+            "Scripts/Generate/generate_water_gate_runtime_tables.py",
+            "Dungeons/generated/water_fill_table.asm",
+            "Dungeons/generated/water_gate_runtime_tables.asm",
+        ):
+            copy_repo_file(REPO_ROOT, repo, relative)
+
+        verifier = repo / "Scripts/Build/verify_feature_flags.py"
+        verifier.write_text("print('Feature flags OK (transaction fixture).')\n")
+
+        fake_asar = root / "fake-asar"
+        fake_asar.write_text("#!/bin/sh\nexit 0\n")
+        fake_asar.chmod(0o755)
+
+        rom_dir = repo / "Roms"
+        rom_dir.mkdir()
+        base_data = bytes(ROM_SIZE)
+        patched_data = bytearray(base_data)
+        patched_data[0x40] = 0xA5  # Proves assemble_rom mutates the output.
+        (rom_dir / "oos168.sfc").write_bytes(base_data)
+        (rom_dir / "oos168x.sfc").write_bytes(patched_data)
+        return repo, fake_asar
+
+    def run_refresh(
+        self, root: Path, repo: Path, fake_asar: Path, authoring_rom: Path
+    ) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env.update(
+            {
+                "OOS_BACKUP_ROOT": str(root / "backups"),
+                "OOS_REFRESH_WATER_TABLES": "1",
+                "OOS_SKIP_MENU_VALIDATE": "1",
+                "OOS_WATER_FILL_TABLE_ROM": str(authoring_rom),
+            }
+        )
+        return subprocess.run(
+            [
+                str(repo / "Scripts/Build/build_rom.sh"),
+                "168",
+                str(fake_asar),
+                "--no-symbols",
+                "--skip-tests",
+            ],
+            cwd=repo,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def assert_transaction_restored(
+        self,
+        repo: Path,
+        patched_before: bytes,
+        fill_before: bytes,
+        runtime_before: bytes,
+    ) -> None:
+        self.assertEqual((repo / "Roms/oos168x.sfc").read_bytes(), patched_before)
+        self.assertEqual(
+            (repo / "Dungeons/generated/water_fill_table.asm").read_bytes(),
+            fill_before,
+        )
+        self.assertEqual(
+            (repo / "Dungeons/generated/water_gate_runtime_tables.asm").read_bytes(),
+            runtime_before,
+        )
+
+    def test_failed_generation_restores_patched_rom_and_tracked_tables(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo, fake_asar = self.prepare_fixture(root)
+            authoring_rom = root / "authoring-missing-room27.sfc"
+            make_authoring_rom(authoring_rom, (0x25,))
+
+            patched_before = (repo / "Roms/oos168x.sfc").read_bytes()
+            fill_before = (
+                repo / "Dungeons/generated/water_fill_table.asm"
+            ).read_bytes()
+            runtime_before = (
+                repo / "Dungeons/generated/water_gate_runtime_tables.asm"
+            ).read_bytes()
+
+            result = self.run_refresh(root, repo, fake_asar, authoring_rom)
+
+            combined_output = result.stdout + result.stderr
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(
+                "Required water-fill rooms have no marker tiles: 0x27",
+                combined_output,
+            )
+            self.assertIn(
+                "Restored water includes and patched ROM after failed refresh",
+                combined_output,
+            )
+            self.assert_transaction_restored(
+                repo, patched_before, fill_before, runtime_before
+            )
+
+    def test_failed_post_stage_check_restores_patched_rom_and_tracked_tables(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo, fake_asar = self.prepare_fixture(root)
+            authoring_rom = root / "authoring-complete.sfc"
+            make_authoring_rom(authoring_rom, (0x25, 0x27))
+
+            post_stage_check = repo / "Scripts/Build/check_zscream_overlap.py"
+            post_stage_check.write_text(
+                "import sys\nprint('intentional post-stage failure')\nsys.exit(23)\n"
+            )
+
+            patched_before = (repo / "Roms/oos168x.sfc").read_bytes()
+            fill_before = (
+                repo / "Dungeons/generated/water_fill_table.asm"
+            ).read_bytes()
+            runtime_before = (
+                repo / "Dungeons/generated/water_gate_runtime_tables.asm"
+            ).read_bytes()
+
+            result = self.run_refresh(root, repo, fake_asar, authoring_rom)
+
+            combined_output = result.stdout + result.stderr
+            self.assertEqual(result.returncode, 23, combined_output)
+            self.assertIn("Water table candidates staged", combined_output)
+            self.assertIn("intentional post-stage failure", combined_output)
+            self.assertIn(
+                "Restored water includes and patched ROM after failed refresh",
+                combined_output,
+            )
+            self.assert_transaction_restored(
+                repo, patched_before, fill_before, runtime_before
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/unit/test_water_fill_generation.py
+++ b/Tests/unit/test_water_fill_generation.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from Scripts.Generate import generate_water_fill_table as water_fill
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GENERATOR = REPO_ROOT / "Scripts/Generate/generate_water_fill_table.py"
+TRACKED_TABLE = REPO_ROOT / "Dungeons/generated/water_fill_table.asm"
+ROM_SIZE = 0x130000
+
+
+def pc_to_lorom(pc: int) -> int:
+    bank = (pc >> 15) & 0x7F
+    address = (pc & 0x7FFF) | 0x8000
+    return (bank << 16) | address
+
+
+def make_marker_rom(path: Path, rooms: tuple[int, ...]) -> None:
+    data = bytearray(ROM_SIZE)
+    pointer_table = water_fill.snes_to_pc(water_fill.ROOM_POINTER_SNES)
+
+    for index, room_id in enumerate(rooms):
+        stream_pc = water_fill.CUSTOM_COLLISION_DATA_PC_START + (index * 0x10)
+        stream_snes = pc_to_lorom(stream_pc)
+        pointer_pc = pointer_table + (room_id * 3)
+        data[pointer_pc : pointer_pc + 3] = stream_snes.to_bytes(3, "little")
+
+        # Single-tile stream: marker, one offset/tile pair, terminator.
+        data[stream_pc : stream_pc + 7] = bytes(
+            (0xF0, 0xF0, room_id, 0x01, 0xF5, 0xFF, 0xFF)
+        )
+
+    path.write_bytes(data)
+
+
+class WaterFillGenerationTest(unittest.TestCase):
+    def run_generator(self, rom: Path, output: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(GENERATOR),
+                "--rom",
+                str(rom),
+                "--out-asm",
+                str(output),
+                "--require-rooms",
+                "0x25,0x27",
+            ],
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_required_rooms_reject_incomplete_authoring_rom(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            rom = root / "authoring.sfc"
+            output = root / "water_fill_table.asm"
+            make_marker_rom(rom, (0x25,))
+
+            result = self.run_generator(rom, output)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(
+                "Required water-fill rooms have no marker tiles: 0x27",
+                result.stderr,
+            )
+            self.assertFalse(output.exists())
+
+    def test_required_rooms_generate_complete_d4_table(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            rom = root / "authoring.sfc"
+            output = root / "water_fill_table.asm"
+            make_marker_rom(rom, (0x25, 0x27))
+
+            result = self.run_generator(rom, output)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            generated = output.read_text()
+            self.assertIn("  db $02", generated)
+            self.assertIn("  db $25, $02 : dw $0009 ; tiles=1", generated)
+            self.assertIn("  db $27, $01 : dw $000C ; tiles=1", generated)
+
+    def test_tracked_release_table_keeps_both_d4_rooms(self) -> None:
+        tracked = TRACKED_TABLE.read_text()
+        self.assertIn("  db $25, $02 : dw $0009 ; tiles=168", tracked)
+        self.assertIn("  db $27, $01 : dw $015A ; tiles=222", tracked)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/unit/test_water_fill_generation.py
+++ b/Tests/unit/test_water_fill_generation.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 import tempfile
 import unittest
+from dataclasses import dataclass
 from pathlib import Path
 
 from Scripts.Generate import generate_water_fill_table as water_fill
@@ -13,6 +15,80 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 GENERATOR = REPO_ROOT / "Scripts/Generate/generate_water_fill_table.py"
 TRACKED_TABLE = REPO_ROOT / "Dungeons/generated/water_fill_table.asm"
 ROM_SIZE = 0x130000
+
+
+@dataclass(frozen=True)
+class ParsedZone:
+    room_id: int
+    mask: int
+    data_offset: int
+    tile_count: int
+    payload: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class ParsedTable:
+    zone_count: int
+    zones: tuple[ParsedZone, ...]
+
+
+def parse_emitted_table(asm: str) -> ParsedTable:
+    """Parse runtime directives, deliberately ignoring all `; tiles=` comments."""
+    header = re.search(
+        r"WaterFillTable_Generated:\s*\{\s*db\s+\$([0-9A-Fa-f]+)(.*?)\}",
+        asm,
+        re.DOTALL,
+    )
+    if not header:
+        raise ValueError("WaterFillTable_Generated block not found")
+
+    zone_count = int(header.group(1), 16)
+    entry_matches = re.findall(
+        r"^\s*db\s+\$([0-9A-Fa-f]+),\s*\$([0-9A-Fa-f]+)\s*"
+        r":\s*dw\s+\$([0-9A-Fa-f]+)",
+        header.group(2),
+        re.MULTILINE,
+    )
+
+    zones: list[ParsedZone] = []
+    for room_raw, mask_raw, offset_raw in entry_matches:
+        room_id = int(room_raw, 16)
+        data_block = re.search(
+            rf"WaterFillData_Room{room_id:02X}:\s*\{{(.*?)\}}",
+            asm,
+            re.DOTALL,
+        )
+        if not data_block:
+            raise ValueError(f"WaterFillData_Room{room_id:02X} block not found")
+
+        count_match = re.search(
+            r"^\s*db\s+\$([0-9A-Fa-f]+)",
+            data_block.group(1),
+            re.MULTILINE,
+        )
+        if not count_match:
+            raise ValueError(f"Room {room_id:02X} count directive not found")
+
+        payload: list[int] = []
+        for values in re.findall(
+            r"^\s*dw\s+([^;\n]+)", data_block.group(1), re.MULTILINE
+        ):
+            payload.extend(
+                int(raw, 16)
+                for raw in re.findall(r"\$([0-9A-Fa-f]+)", values)
+            )
+
+        zones.append(
+            ParsedZone(
+                room_id=room_id,
+                mask=int(mask_raw, 16),
+                data_offset=int(offset_raw, 16),
+                tile_count=int(count_match.group(1), 16),
+                payload=tuple(payload),
+            )
+        )
+
+    return ParsedTable(zone_count=zone_count, zones=tuple(zones))
 
 
 def pc_to_lorom(pc: int) -> int:
@@ -59,20 +135,26 @@ class WaterFillGenerationTest(unittest.TestCase):
         )
 
     def test_required_rooms_reject_incomplete_authoring_rom(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            rom = root / "authoring.sfc"
-            output = root / "water_fill_table.asm"
-            make_marker_rom(rom, (0x25,))
+        cases = (
+            ((0x25,), "0x27"),
+            ((0x27,), "0x25"),
+            ((), "0x25, 0x27"),
+        )
+        for rooms, missing in cases:
+            with self.subTest(rooms=rooms), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                rom = root / "authoring.sfc"
+                output = root / "water_fill_table.asm"
+                make_marker_rom(rom, rooms)
 
-            result = self.run_generator(rom, output)
+                result = self.run_generator(rom, output)
 
-            self.assertNotEqual(result.returncode, 0)
-            self.assertIn(
-                "Required water-fill rooms have no marker tiles: 0x27",
-                result.stderr,
-            )
-            self.assertFalse(output.exists())
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(
+                    f"Required water-fill rooms have no marker tiles: {missing}",
+                    result.stderr,
+                )
+                self.assertFalse(output.exists())
 
     def test_required_rooms_generate_complete_d4_table(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -84,15 +166,36 @@ class WaterFillGenerationTest(unittest.TestCase):
             result = self.run_generator(rom, output)
 
             self.assertEqual(result.returncode, 0, result.stderr)
-            generated = output.read_text()
-            self.assertIn("  db $02", generated)
-            self.assertIn("  db $25, $02 : dw $0009 ; tiles=1", generated)
-            self.assertIn("  db $27, $01 : dw $000C ; tiles=1", generated)
+            table = parse_emitted_table(output.read_text())
+            self.assertEqual(table.zone_count, 2)
+            self.assertEqual(
+                table.zones,
+                (
+                    ParsedZone(0x25, 0x02, 0x0009, 1, (0x0125,)),
+                    ParsedZone(0x27, 0x01, 0x000C, 1, (0x0127,)),
+                ),
+            )
 
     def test_tracked_release_table_keeps_both_d4_rooms(self) -> None:
-        tracked = TRACKED_TABLE.read_text()
-        self.assertIn("  db $25, $02 : dw $0009 ; tiles=168", tracked)
-        self.assertIn("  db $27, $01 : dw $015A ; tiles=222", tracked)
+        table = parse_emitted_table(TRACKED_TABLE.read_text())
+        self.assertEqual(table.zone_count, 2)
+        self.assertEqual(len(table.zones), table.zone_count)
+
+        expected = (
+            (0x25, 0x02, 0x0009, 0xA8),
+            (0x27, 0x01, 0x015A, 0xDE),
+        )
+        running_offset = 1 + (table.zone_count * 4)
+        for zone, (room_id, mask, data_offset, tile_count) in zip(
+            table.zones, expected, strict=True
+        ):
+            self.assertEqual(zone.room_id, room_id)
+            self.assertEqual(zone.mask, mask)
+            self.assertEqual(zone.data_offset, data_offset)
+            self.assertEqual(zone.data_offset, running_offset)
+            self.assertEqual(zone.tile_count, tile_count)
+            self.assertEqual(len(zone.payload), tile_count)
+            running_offset += 1 + (len(zone.payload) * 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Make explicit water-table refresh a whole-build transaction: snapshot the patched ROM and both tracked includes before the first assembly mutation, then restore all three on generation, rebuild, or downstream-check failure.
- Add whole-build regression fixtures for missing-room generation failure and a post-stage failure after both candidate includes were installed.
- Add synthetic-ROM generator coverage for missing room `0x25`, missing room `0x27`, and both missing; no failed candidate is written.
- Parse actual emitted `db` count directives and `dw` payload blocks instead of trusting `; tiles=` comments. Assert the tracked runtime layout is room `0x25` / `0xA8` / 168 payload words at `0x0009` and room `0x27` / `0xDE` / 222 payload words at `0x015A`.
- Correct the water-collision handoff and workflow-alignment docs: normal builds consume both tracked release tables; only an explicit refresh regenerates them from a trusted authoring ROM.

## Root cause

The old build flow generated from the previous patched output and then copied the base ROM over that output before assembly. Room `0x27` markers existed only in the edited prior output, so the first build retained the runtime table but consumed the markers. A second generation then silently dropped room `0x27`. `dungeon-oracle-preflight --required-collision-rooms=0x25,0x27` did not catch this because it checks for any authored collision data, not water-fill table membership.

PR #107 introduced tracked release tables, explicit refresh, and `--require-rooms 0x25,0x27`. Its first transaction implementation armed rollback only after initial assembly and candidate generation, so a failed missing-room refresh still changed `oos168x.sfc`. This stacked PR moves transaction setup ahead of `assemble_rom` and keeps rollback armed through all later checks.

## Verification

- `python3 -m unittest -v Tests.unit.test_water_fill_generation Tests.unit.test_water_fill_build_transaction` — 5 passed.
- `python3 -m unittest discover -s Tests/unit -v` — 42 passed.
- `python3 Scripts/Analysis/lint_docs.py` — passed.
- `python3 -m py_compile Tests/unit/test_water_fill_generation.py Tests/unit/test_water_fill_build_transaction.py` — passed.
- `bash -n Scripts/Build/build_rom.sh` — passed.
- `shellcheck -e SC2034 Scripts/Build/build_rom.sh` — passed (`SC2034` is the pre-existing unused `mlb_path` warning).
- `git diff --check` — passed.
- Exact-head workflow dispatch: [ROM Tests run 29464232858](https://github.com/scawful/Oracle-of-Secrets/actions/runs/29464232858) completed successfully at `6e40a17`: ASM, Lua, Python/metadata safety, and Test Summary passed; emulator tests were intentionally skipped.

### Disposable ROM behavior

Workspace: `/private/tmp/oos-water-transaction.2ie2T5` (source ROMs copied; no canonical writes).

- Missing-room refresh: exit `1` with `Required water-fill rooms have no marker tiles: 0x27`; patched ROM restored byte-exact to SHA-256 `fc234d88edeaed676a9cca14f319847dccc172caa11b45894c95953dd9ff9b0f`; both tracked include SHA-256 values also restored exactly.
- Complete refresh: exit `0`; candidate pair validated and promoted; rebuilt ROM SHA-256 `e44d8174fc4c505c2cbdc316664fc5250dd2016a499ad640a07ce5e6a565e4c1`; compiled runtime table contains room `0x25` count/payload `168/168` and room `0x27` count/payload `222/222` at offsets `0x0009` and `0x015A`.
- The rebuilt output intentionally retains only room `0x25` authoring markers, confirming normal runtime completeness no longer depends on markers surviving patched output.
- All source input hashes were unchanged after failure and success runs.

## Dependency

Stacked on draft PR #107 (`codex/yaze-prereq-repair`). Merge or retarget after #107; this PR is not intended to bypass its manual Yaze and emulator gates.


