### PR TITLE
fix(workflow): keep expanded messages ASM-owned

### DIFF
--- a/Docs/Planning/Plans/essence_maiden_presentation.md
+++ b/Docs/Planning/Plans/essence_maiden_presentation.md
@@ -2,7 +2,13 @@
 
 ## Summary
 
-Refine the crystal maiden dialogue and essence collection text to strengthen the game's Oracle identity while working within existing mechanical and graphical constraints.\n+\n+Dialogue authoring is **not blocked**: edit `Core/messages.org` (and any associated message tables) and rebuild the ROM. yaze GUI support is a convenience item, not a dependency.
+Refine the crystal maiden dialogue and essence collection text to strengthen
+the game's Oracle identity while working within existing mechanical and
+graphical constraints.
+
+Dialogue authoring is **not blocked**: use `Core/messages.org` for vanilla
+messages and `Core/message.asm` for expanded IDs, then rebuild the ROM. yaze
+GUI support is a convenience item, not a dependency.
 
 ## Current State
 
@@ -67,14 +73,17 @@ Complete the Maku Tree hint dispatch for all 7 dungeons. Currently D1, D3, D5 ar
 
 The menu GFX sheet is fully allocated with custom item icons, masks, fonts, and UI elements. Unique per-essence icons would require sacrificing existing graphics. The triforce triangle icons are compact and functional. **Decision: Keep triforce icons.**
 
-### Yaze Message Editor (AVAILABLE)
+### Expanded Message Workflow (AVAILABLE)
 
-The yaze message editor expanded write path is functional as of commit `4b6a78ed` (2026-02-06). Both the GUI (Ctrl+S) and z3ed CLI (`message-write`) write directly to main ROM with capacity validation. Dialogue authoring is **unblocked**.
+Expanded message IDs `$18D+` live in ASM-owned bank `$2F`. Direct editor or
+CLI writes to those IDs are not durable because the next ASM build replaces
+the bank. Dialogue authoring remains **unblocked** through the ASM source.
 
-**Workflow options:**
-1. Edit `Core/message.asm` hex directly and rebuild (`Scripts/Build/build_rom.sh 168`)
-2. Use z3ed CLI: `z3ed message-write --rom <rom> --id <id> --text "<text>"`
-3. Use yaze GUI message editor (expanded bank save works)
+**Expanded-message workflow:**
+1. Edit the matching entry in `Core/message.asm`.
+2. Rebuild with `Scripts/Build/build_rom.sh 168`.
+3. Reopen or reload `Roms/oos168x.sfc` for inspection and testing; do not edit
+   the patched ROM directly.
 
 **Ready to author:**
 - Essence collection text (items 1 above)

--- a/Docs/Planning/Plans/intro_and_quest_chain_improvements.md
+++ b/Docs/Planning/Plans/intro_and_quest_chain_improvements.md
@@ -202,7 +202,10 @@ Options (ranked by effort):
 
 ## Dependencies
 
-- Dialogue changes are **UNBLOCKED** — yaze message editor + z3ed CLI both support expanded write path (commit `4b6a78ed`). Edit `Core/message.asm` or use tooling.
+- Dialogue changes are **UNBLOCKED**. For expanded IDs `$18D+`, edit
+  `Core/message.asm`, rebuild with `Scripts/Build/build_rom.sh 168`, then reopen
+  or reload `Roms/oos168x.sfc` for inspection. Direct editor/CLI writes to
+  ASM-owned bank `$2F` are not durable, and the patched ROM is test-only.
 - Elder woman dialogue revision coordinates with `gossip_stone_additions.md` (shouldn't duplicate stone content)
 - Maku Tree speech revision coordinates with `maku_tree_hint_cascade.md`
 - Journal entry improvements are ASM changes to `menu_journal.asm` — may not need message editor

--- a/Roms/hack_manifest.json
+++ b/Roms/hack_manifest.json
@@ -3677,10 +3677,10 @@
     ]
   },
   "messages": {
-    "description": "Expanded message system. Vanilla messages ($000-$18C) live in bank $0E of the dev ROM \u2014 yaze can edit these. Expanded messages ($18D+) live in bank $2F, owned by ASM. The hook at $0ED436 redirects message reads for expanded IDs. Yaze's message-write CLI can target expanded IDs if it knows the data region bounds.",
+    "description": "Expanded message system. Vanilla messages ($000-$18C) live in bank $0E of the dev ROM \u2014 yaze can edit these. Expanded messages ($18D+) live in bank $2F, owned by ASM. The hook at $0ED436 redirects message reads for expanded IDs. Direct editor or CLI writes to expanded IDs are not durable because the next ASM rebuild replaces bank $2F.",
     "editing_guidance": {
       "vanilla_safe": "Message IDs $000-$18C can be edited in the dev ROM via yaze",
-      "expanded_asm_owned": "Message IDs $18D+ are in bank $2F; edit via Core/message.asm or z3ed message-write CLI",
+      "expanded_asm_owned": "Message IDs $18D+ are in ASM-owned bank $2F; edit Core/message.asm, rebuild with Scripts/Build/build_rom.sh 168, then reopen or reload Roms/oos168x.sfc for inspection. Do not edit the patched ROM directly.",
       "hook_address": "$0ED436 (do not overwrite \u2014 asar patches this)"
     },
     "hook_address": "0x0ED436",

--- a/Scripts/Generate/generate_hack_manifest.py
+++ b/Scripts/Generate/generate_hack_manifest.py
@@ -675,10 +675,10 @@ def generate_manifest(root: Path, rom_path: Optional[Path] = None) -> dict:
     messages = scan_message_layout(root)
     if messages:
         manifest["messages"] = {
-            "description": "Expanded message system. Vanilla messages ($000-$18C) live in bank $0E of the dev ROM — yaze can edit these. Expanded messages ($18D+) live in bank $2F, owned by ASM. The hook at $0ED436 redirects message reads for expanded IDs. Yaze's message-write CLI can target expanded IDs if it knows the data region bounds.",
+            "description": "Expanded message system. Vanilla messages ($000-$18C) live in bank $0E of the dev ROM — yaze can edit these. Expanded messages ($18D+) live in bank $2F, owned by ASM. The hook at $0ED436 redirects message reads for expanded IDs. Direct editor or CLI writes to expanded IDs are not durable because the next ASM rebuild replaces bank $2F.",
             "editing_guidance": {
                 "vanilla_safe": "Message IDs $000-$18C can be edited in the dev ROM via yaze",
-                "expanded_asm_owned": "Message IDs $18D+ are in bank $2F; edit via Core/message.asm or z3ed message-write CLI",
+                "expanded_asm_owned": "Message IDs $18D+ are in ASM-owned bank $2F; edit Core/message.asm, rebuild with Scripts/Build/build_rom.sh 168, then reopen or reload Roms/oos168x.sfc for inspection. Do not edit the patched ROM directly.",
                 "hook_address": "$0ED436 (do not overwrite — asar patches this)",
             },
             **messages,

--- a/Tests/unit/test_generate_hack_manifest.py
+++ b/Tests/unit/test_generate_hack_manifest.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "Scripts" / "Generate"))
+
+from generate_hack_manifest import generate_manifest
+
+
+class HackManifestMessagePolicyTest(unittest.TestCase):
+    def test_expanded_messages_require_asm_rebuild_workflow(self) -> None:
+        generated_messages = generate_manifest(REPO_ROOT)["messages"]
+        tracked_messages = json.loads(
+            (REPO_ROOT / "Roms" / "hack_manifest.json").read_text(encoding="utf-8")
+        )["messages"]
+
+        self.assertEqual(generated_messages, tracked_messages)
+
+        guidance = generated_messages["editing_guidance"]["expanded_asm_owned"]
+        self.assertIn("ASM-owned bank $2F", guidance)
+        self.assertIn("Core/message.asm", guidance)
+        self.assertIn("Scripts/Build/build_rom.sh 168", guidance)
+        self.assertIn("reopen or reload", guidance)
+
+        policy_text = json.dumps(generated_messages)
+        self.assertNotIn("message-write", policy_text)
+        self.assertNotIn("z3ed", policy_text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- declare expanded IDs `$18D+` / bank `$2F` as ASM-owned and non-durable under direct editor/CLI ROM writes
- replace unsafe `message-write` guidance with the durable workflow: edit `Core/message.asm`, rebuild `168`, then reopen/reload the disposable patched ROM
- keep the generated and tracked hack-manifest message policy identical
- correct two active planning documents that still recommended direct expanded-bank writes
- add a focused generator regression that rejects reintroduction of `message-write`/`z3ed` guidance

## Verification
- `python3 -m unittest Tests.unit.test_generate_hack_manifest` — 1/1 passed
- `python3 Scripts/Analysis/lint_docs.py` — passed
- `python3 -m json.tool Roms/hack_manifest.json` — passed
- generated message section equals tracked manifest section
- `git diff --check` — passed
- no tracked `message-write` guidance remains outside the regression assertion

## Stack
- base: #107 (`codex/yaze-prereq-repair`)
- paired Yaze CLI fail-closed enforcement is being prepared separately

No ROM was generated or modified by this change.
