### PR TITLE
fix(integration): gate PR #107 prerequisites safely

### DIFF
--- a/.github/workflows/test-rom.yml
+++ b/.github/workflows/test-rom.yml
@@ -167,7 +167,8 @@ jobs:
             echo "Base ROM found"
           else
             echo "rom_available=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::Base ROM not found at ~/roms/alttp/oos168.sfc"
+            echo "::error::Base ROM not found at ~/roms/alttp/oos168.sfc"
+            exit 1
           fi
 
       - name: Build Patched ROM
@@ -177,7 +178,8 @@ jobs:
           cp ~/roms/alttp/oos168.sfc Roms/
 
           # Build patched ROM
-          ASAR_BIN="${ASAR_BIN:-asar}" ./Scripts/Build/build_rom.sh 168
+          OOS_GENERATE_HOOKS=1 OOS_VALIDATE_HOOKS=1 \
+            ASAR_BIN="${ASAR_BIN:-asar}" ./Scripts/Build/build_rom.sh 168
 
       - name: Run Boot Test
         if: steps.check-rom.outputs.rom_available == 'true'
@@ -188,7 +190,6 @@ jobs:
             Roms/oos168x.sfc
 
           echo "Boot test passed"
-        continue-on-error: true
 
       - name: Upload Test Logs
         if: always() && steps.check-rom.outputs.rom_available == 'true'

--- a/Docs/Debugging/Issues/WaterCollision_Handoff.md
+++ b/Docs/Debugging/Issues/WaterCollision_Handoff.md
@@ -21,7 +21,8 @@ Applied data-driven fixes for active Zora Baby + water gate regressions:
 - `Scripts/Generate/generate_water_gate_runtime_tables.py` (new)
   - Extracts room overlay object streams (default object ids `0xC9,0xD9`) and Zora Baby switch targets from ROM room data.
 - `Scripts/Build/build_rom.sh`
-  - Auto-runs table generation before assembly, preferring `Oracle-of-Secrets.yaze` `rom_filename` as source ROM.
+  - Normal builds assemble the tracked generated tables as release source.
+  - Table refresh is explicit and transactional via `OOS_REFRESH_WATER_TABLES=1` plus an authoring ROM.
 
 Runtime expectations to verify:
 
@@ -45,10 +46,13 @@ Use these room-data controls to drive runtime behavior without hand-editing ASM:
 - Water fill collision zones (switch-activated):
   - Paint custom collision tile `0xF5` in the room where water should become swimmable after switch activation.
   - `CustomRoomCollision` now treats `0xF5` as an authoring marker and does **not** apply it during normal room load.
-  - Build regenerates `Dungeons/generated/water_fill_table.asm` (ROM `$25:E000`) from those marker offsets.
+  - An explicit refresh regenerates `Dungeons/generated/water_fill_table.asm` (ROM `$25:E000`) from those marker offsets.
   - At water fill completion, runtime writes deep-water collision (`0x08`) to those offsets.
   - Preset-driven CLI workflow (recommended):
-    - `python3 Scripts/Generate/water_fill_author.py --rom Roms/oos168.sfc --preset zora_d4 --write`
+    - Author only on the trusted editable base ROM or a disposable scratch copy, never `Roms/oos168x.sfc`.
+    - `python3 Scripts/Generate/water_fill_author.py --rom <authoring-rom> --preset zora_d4 --write`
+    - `OOS_REFRESH_WATER_TABLES=1 OOS_WATER_FILL_TABLE_ROM=<authoring-rom> ./Scripts/Build/build_rom.sh 168`
+    - Refresh fails unless both required rooms (`0x25`, `0x27`) still contain marker tiles. The two generated water-table includes are promoted together only after a successful rebuild.
     - Presets:
       - `room25_lower_band` (lower-half drain band)
       - `room27_upside_t` (dam upside-T with right-side stair gap)
@@ -116,7 +120,10 @@ Room entry re-applies collision if the bit is set.
 
 - Script: `python3 Scripts/Generate/generate_water_gate_runtime_tables.py --rom <rom>`
 - Script: `python3 Scripts/Generate/generate_water_fill_table.py --rom <rom>`
-- Auto-run during build (`Scripts/Build/build_rom.sh`) unless `OOS_SKIP_WATER_TABLE_GEN=1`.
+- Normal builds use the tracked generated includes. This keeps repeated builds stable even though patched build output does not retain every `0xF5` authoring marker.
+- Refresh both includes explicitly with:
+  - `OOS_REFRESH_WATER_TABLES=1 OOS_WATER_FILL_TABLE_ROM=<authoring-rom> ./Scripts/Build/build_rom.sh 168`
+- The refresh is transactional and requires marker data for rooms `0x25` and `0x27`; a failed generation or rebuild restores the previous include pair and patched ROM.
 - Outputs:
   - `WaterOverlayRoomTable` / `WaterOverlayData_*` (from object ids `0xC9,0xD9` by default)
   - `ZoraBabySwitchTargetTable` (marker priority default: `0x124,0x137,0x135`)

--- a/Docs/Debugging/Issues/WaterCollision_Handoff.md
+++ b/Docs/Debugging/Issues/WaterCollision_Handoff.md
@@ -34,15 +34,20 @@ Runtime expectations to verify:
 
 Use these room-data controls to drive runtime behavior without hand-editing ASM:
 
+Normal builds consume the tracked `Dungeons/generated/water_gate_runtime_tables.asm`
+and `Dungeons/generated/water_fill_table.asm` release sources. Only an explicit,
+transactional water-table refresh regenerates both includes from the selected
+authoring ROM.
+
 - Water drain/gate overlay segments:
   - Place water overlay objects in the room (`0x0C9` flood and/or `0x0D9` swim-mask forms).
-  - Build regenerates `WaterOverlayRoomTable` automatically.
+  - An explicit refresh regenerates `WaterOverlayRoomTable`.
 - Zora Baby post-switch walk target:
   - Place one marker object near the desired destination using ids in priority order:
     - `0x0124` (preferred)
     - `0x0137`
     - `0x0135`
-  - Build regenerates `ZoraBabySwitchTargetTable`; baby picks the nearest marker at runtime.
+  - An explicit refresh regenerates `ZoraBabySwitchTargetTable`; baby picks the nearest marker at runtime.
 - Water fill collision zones (switch-activated):
   - Paint custom collision tile `0xF5` in the room where water should become swimmable after switch activation.
   - `CustomRoomCollision` now treats `0xF5` as an authoring marker and does **not** apply it during normal room load.

--- a/Docs/Planning/Plans/development_workflow_alignment_2026-03-28.md
+++ b/Docs/Planning/Plans/development_workflow_alignment_2026-03-28.md
@@ -36,7 +36,8 @@ before large new feature pushes.
 
 - `Scripts/Build/build_rom.sh` now does more than assembly:
   - menu validation
-  - water table generation
+  - tracked water-table consumption on normal builds; generation only during an
+    explicit opt-in refresh
   - `check_zscream_overlap.py`
   - hooks.json regeneration
   - optional sprite/hook validation

--- a/Docs/Planning/Plans/essence_maiden_presentation.md
+++ b/Docs/Planning/Plans/essence_maiden_presentation.md
@@ -2,7 +2,13 @@
 
 ## Summary
 
-Refine the crystal maiden dialogue and essence collection text to strengthen the game's Oracle identity while working within existing mechanical and graphical constraints.\n+\n+Dialogue authoring is **not blocked**: edit `Core/messages.org` (and any associated message tables) and rebuild the ROM. yaze GUI support is a convenience item, not a dependency.
+Refine the crystal maiden dialogue and essence collection text to strengthen
+the game's Oracle identity while working within existing mechanical and
+graphical constraints.
+
+Dialogue authoring is **not blocked**: use `Core/messages.org` for vanilla
+messages and `Core/message.asm` for expanded IDs, then rebuild the ROM. yaze
+GUI support is a convenience item, not a dependency.
 
 ## Current State
 
@@ -67,14 +73,17 @@ Complete the Maku Tree hint dispatch for all 7 dungeons. Currently D1, D3, D5 ar
 
 The menu GFX sheet is fully allocated with custom item icons, masks, fonts, and UI elements. Unique per-essence icons would require sacrificing existing graphics. The triforce triangle icons are compact and functional. **Decision: Keep triforce icons.**
 
-### Yaze Message Editor (AVAILABLE)
+### Expanded Message Workflow (AVAILABLE)
 
-The yaze message editor expanded write path is functional as of commit `4b6a78ed` (2026-02-06). Both the GUI (Ctrl+S) and z3ed CLI (`message-write`) write directly to main ROM with capacity validation. Dialogue authoring is **unblocked**.
+Expanded message IDs `$18D+` live in ASM-owned bank `$2F`. Direct editor or
+CLI writes to those IDs are not durable because the next ASM build replaces
+the bank. Dialogue authoring remains **unblocked** through the ASM source.
 
-**Workflow options:**
-1. Edit `Core/message.asm` hex directly and rebuild (`Scripts/Build/build_rom.sh 168`)
-2. Use z3ed CLI: `z3ed message-write --rom <rom> --id <id> --text "<text>"`
-3. Use yaze GUI message editor (expanded bank save works)
+**Expanded-message workflow:**
+1. Edit the matching entry in `Core/message.asm`.
+2. Rebuild with `Scripts/Build/build_rom.sh 168`.
+3. Reopen or reload `Roms/oos168x.sfc` for inspection and testing; do not edit
+   the patched ROM directly.
 
 **Ready to author:**
 - Essence collection text (items 1 above)

--- a/Docs/Planning/Plans/essence_maiden_presentation.md
+++ b/Docs/Planning/Plans/essence_maiden_presentation.md
@@ -6,15 +6,19 @@ Refine the crystal maiden dialogue and essence collection text to strengthen
 the game's Oracle identity while working within existing mechanical and
 graphical constraints.
 
-Dialogue authoring is **not blocked**: use `Core/messages.org` for vanilla
-messages and `Core/message.asm` for expanded IDs, then rebuild the ROM. yaze
-GUI support is a convenience item, not a dependency.
+Dialogue authoring is **not blocked**. For vanilla IDs `$000-$18C`, preserve
+the change in a committed `Data/dialogue/*.json` bundle, import it into the
+editable base ROM (`Roms/oos168.sfc`) with yaze or z3ed, then close/reopen and
+read it back before rebuilding. The gitignored ROM edit alone is not durable.
+`Core/messages.org` is documentation only, not a build input. Expanded IDs
+`$18D+` remain ASM-owned in `Core/message.asm`.
 
 ## Current State
 
 ### What Works
 
-- **Crystal maidens deliver plot-critical lore** after each dungeon boss (D1-D7)
+- **Crystal maiden text exists for D1-D7**, but delivery is runtime-unverified
+  and the OFF-by-default D7 rescue scaffold does not complete the maiden flow
 - **Three-layer lore system** is well-designed: maidens (long-form) + Maku Tree (guidance) + Gossip Stones (deep lore)
 - **Maiden dialogue is already Oracle-specific** — covers Kalyxo history, Zora technology, Twinrova conspiracy, Goron alliance, endgame setup
 - **Triforce icons in quest menu** are functional and compact given the full GFX tile sheet
@@ -111,8 +115,10 @@ Ridoyie has offered to contribute maiden dialogue and world lore text. Tooling i
 
 | File | Change | Status |
 |---|---|---|
-| `Core/messages.org` | Essence receipt text, maiden dialogue rewrites | Ready to author |
-| `Core/message.asm` | Compiled from messages.org | Ready to author |
+| `Data/dialogue/*.json` | Committed source artifact for vanilla-message changes | Ready to author |
+| `Roms/oos168.sfc` | Import target for vanilla-message bundles; close/reopen/read back before rebuilding | Ready to author |
+| `Core/messages.org` | Documentation/reference only; keep annotations synchronized with verified ROM text | Not a build input |
+| `Core/message.asm` | ASM source for expanded message IDs `$18D+` | Ready to author |
 | `Sprites/NPCs/maku_tree.asm` | Threshold-based dialogue | Done (UNTESTED) |
 | `Core/symbols.asm` | Message IDs | Done |
 

--- a/Docs/Planning/Plans/intro_and_quest_chain_improvements.md
+++ b/Docs/Planning/Plans/intro_and_quest_chain_improvements.md
@@ -202,7 +202,10 @@ Options (ranked by effort):
 
 ## Dependencies
 
-- Dialogue changes are **UNBLOCKED** — yaze message editor + z3ed CLI both support expanded write path (commit `4b6a78ed`). Edit `Core/message.asm` or use tooling.
+- Dialogue changes are **UNBLOCKED**. For expanded IDs `$18D+`, edit
+  `Core/message.asm`, rebuild with `Scripts/Build/build_rom.sh 168`, then reopen
+  or reload `Roms/oos168x.sfc` for inspection. Direct editor/CLI writes to
+  ASM-owned bank `$2F` are not durable, and the patched ROM is test-only.
 - Elder woman dialogue revision coordinates with `gossip_stone_additions.md` (shouldn't duplicate stone content)
 - Maku Tree speech revision coordinates with `maku_tree_hint_cascade.md`
 - Journal entry improvements are ASM changes to `menu_journal.asm` — may not need message editor

--- a/Docs/Planning/Plans/pendant_fix_task.md
+++ b/Docs/Planning/Plans/pendant_fix_task.md
@@ -1,35 +1,40 @@
 # Pendant Reward Alignment — Task Description
 
 **Created:** 2026-02-13
-**Last Reviewed:** 2026-02-13
+**Last Reviewed:** 2026-07-24
 **Priority:** HIGH (blocks shrine progression integrity)
 **Owner:** User/Codex (data + runtime verification)
+**Status:** S1/S2 source-patched and statically read back; runtime pickup
+pending. S3 unimplemented.
 
 ---
 
 ## Problem
 
-Shrine pendant rewards are not aligned with Oracle design intent.
+S1/S2 source data is aligned by `Core/patches.asm`, but pickup/progression
+behavior has not been verified in the emulator. S3 Courage still lacks its
+Vaati boss-drop path.
 
-- S1 and S2 currently use wrong chest items.
-- S3 Courage reward should come from Vaati (Vitreous reskin) boss-drop flow, not a chest placement.
+- S1 and S2 need runtime pickup and pendant-state verification.
+- S3 Courage should come from Vaati's (Vitreous reskin) boss-drop flow, not a
+  chest placement.
 
 ## Current State
 
 | Shrine | Current Reward Path | Current Result | Target |
 |--------|---------------------|----------------|--------|
-| S1 Wisdom | Chest in room `0x7A` | `0x38` (Courage) | `0x39` (Wisdom) |
-| S2 Power | Chest in room `0x73` | `0x39` (Wisdom) | `0x3A` (Power) |
+| S1 Wisdom | Chest in room `0x7A` | `0x39` source-patched; z3ed readback confirmed; runtime pickup unverified | `0x39` (Wisdom) |
+| S2 Power | Chest in room `0x73` | `0x3A` source-patched; z3ed readback confirmed; runtime pickup unverified | `0x3A` (Power) |
 | S3 Courage | Boss-drop path (Vaati) not implemented | No Courage reward flow | Vaati awards Courage (`0x38`) |
 
-**Pendant of Power (`0x3A`) does not appear in any chest in the current ROM.**
+Current patched-ROM readback shows Pendant of Power (`0x3A`) in room `0x73`.
 
 ## Required Fixes
 
 | Shrine | Action | Type |
 |--------|--------|------|
-| S1 Wisdom | Change chest item in room `0x7A` from `0x38` -> `0x39` | Data (yaze dungeon editor) |
-| S2 Power | Change chest item in room `0x73` from `0x39` -> `0x3A` | Data (yaze dungeon editor) |
+| S1 Wisdom | Run runtime pickup and pendant SRAM/progression validation | Runtime |
+| S2 Power | Run runtime pickup and pendant SRAM/progression validation | Runtime |
 | S3 Courage | Implement Vaati victory reward path to grant Courage pendant (`0x38`) and set progression bits | ASM/runtime |
 
 ## Pendant Item IDs
@@ -42,13 +47,15 @@ Shrine pendant rewards are not aligned with Oracle design intent.
 
 ---
 
-## How to Fix (Now)
+## Source Fix (Implemented)
 
-### S1/S2 chest swaps (yaze)
-1. Open ROM in yaze.
-2. Room `0x7A`: set big chest item to `0x39`.
-3. Room `0x73`: set big chest item to `0x3A`.
-4. Save ROM.
+`Core/patches.asm` asserts the chest-record identities and writes:
+
+- `$01E9F7 = $39` for room `0x7A` (Wisdom)
+- `$01E9E8 = $3A` for room `0x73` (Power)
+
+Rebuild the patched ROM from the recorded base. Do not treat a direct edit to a
+gitignored ROM as the durable fix.
 
 ### S3 reward path (separate implementation)
 1. Confirm Vaati boss room + defeat flow entrypoint.
@@ -60,8 +67,11 @@ Shrine pendant rewards are not aligned with Oracle design intent.
 ## Verification
 
 ```bash
-# Chest sanity (S1/S2)
-~/src/hobby/yaze/build/bin/z3ed chest-inventory --rom Roms/oos168x.sfc | grep -i pendant
+# Static chest readback (S1/S2)
+../yaze/scripts/z3ed dungeon-list-chests \
+  --rom Roms/oos168x.sfc --room 0x7A --format json
+../yaze/scripts/z3ed dungeon-list-chests \
+  --rom Roms/oos168x.sfc --room 0x73 --format json
 
 # Runtime checks
 python3 Scripts/Mesen2/mesen2_client.py warp-entrance 0x33  # S1
@@ -69,9 +79,13 @@ python3 Scripts/Mesen2/mesen2_client.py warp-entrance 0x09  # S2
 # S3: run Vaati defeat path and verify Courage reward + SRAM progression
 ```
 
-Expected outcome:
-- S1 chest grants Wisdom.
-- S2 chest grants Power.
+Static readback currently confirms:
+- S1 chest data is Wisdom (`0x39`).
+- S2 chest data is Power (`0x3A`).
+
+Runtime acceptance (pending):
+- S1 pickup grants Wisdom and updates the intended pendant/progression state.
+- S2 pickup grants Power and updates the intended pendant/progression state.
 - S3 Vaati clear grants Courage (no chest dependency).
 
 ---

--- a/Docs/Planning/Plans/rc_content_checklist.md
+++ b/Docs/Planning/Plans/rc_content_checklist.md
@@ -1,6 +1,8 @@
 # Release Candidate Content Checklist
 
 **Created:** 2026-02-12
+**Last assessed:** 2026-07-24 (code/static readback reconciliation; full runtime
+sweep pending)
 **Reference:** `release_2026_definition.md` (RC gate criteria)
 **Purpose:** Track what content is needed before declaring RC. This is the "what's missing" list.
 
@@ -14,8 +16,6 @@
 
 ## Dungeon Playability
 
-**Last assessed:** 2026-02-13 (D5, D7, S1-S3 completed)
-
 | Dungeon | Rooms | Boss | Item | Connectivity | Playable? | Top Blocker |
 |---------|-------|------|------|-------------|-----------|-------------|
 | D1 Mushroom Grotto | Assumed OK | Assumed OK | Assumed OK | Assumed OK | **Unverified** | Runtime test needed |
@@ -24,21 +24,24 @@
 | D4 Zora Temple | 16 assessed | Arrghus coded | Unknown | Partial | **No** | 3 unconverted rooms, water gate untested |
 | D5 Glacia Estate | 19 exist | Twinrova **coded** | Fire Rod **unverified** | **Unmapped** | **No** | Room connectivity unmapped; 5/19 stale labels |
 | D6 Goron Mines | 4 flagged | Unknown | Unknown | Unknown | **No** | Minecart track placement |
-| D7 Dragon Ship | 17 mapped | Kydrog **broken** | Somaria **unverified** | **Good** (20 doors, 6 stairs) | **No** | Boss spriteset wrong; death does nothing; no Farore rescue |
+| D7 Dragon Ship | 17 mapped | Kydrog combat code exists; runtime unverified | Somaria **unverified** | **Good** (20 doors, 6 stairs) | **No** | Rescue scaffold exists but defaults OFF and lacks maiden/warp/NPC/endgame flow |
 | D8 Fortress | Unknown | Dark Link mid-boss | Unknown | Unknown | **Unknown** | Needs full assessment |
-| S1 Shrine of Wisdom | 7 exist | None | Flippers | Partial | **No** | **Wrong pendant in chest** (0x38 not 0x39) |
-| S2 Shrine of Power | 7 rooms mapped in `dungeons.json` | **None (by design)** | Power Glove | Good (mapped set) | **No** | **Wrong pendant** (0x39 not 0x3A); lava collision bug |
+| S1 Shrine of Wisdom | 7 exist | None | Flippers | Partial | **No** | Source-patched/read back as 0x39; runtime pickup unverified |
+| S2 Shrine of Power | 7 rooms mapped in `dungeons.json` | **None (by design)** | Power Glove | Good (mapped set) | **No** | Source-patched/read back as 0x3A; runtime pickup and lava collision unverified |
 | S3 Shrine of Courage | 8 rooms (4 mapped in `dungeons.json`) | **No boss code** (Vaati designed, not implemented) | Mirror Shield | **Partial** | **No** | Remaining rooms not modeled (0x07/0x16/0x23/0x26); Vaati reward path not implemented; entrance shared with D8 |
 
-### Critical Cross-Dungeon Issue: Pendant Items All Wrong
+### Critical Cross-Dungeon Issue: Pendant Reward Alignment
 
-| Shrine | Expected Pendant | Chest Room | Actual Item | Fix |
-|--------|-----------------|------------|-------------|-----|
-| S1 Wisdom | 0x39 (Wisdom) | 0x7A | ~~0x38~~ **FIXED 2026-06-11: 0x39** | Done (chest table patch, verified via z3ed) |
-| S2 Power | 0x3A (Power) | 0x73 | ~~0x39~~ **FIXED 2026-06-11: 0x3A** | Done (chest table patch, verified via z3ed) |
-| S3 Courage | 0x38 (Courage) | Vaati boss clear | Not implemented | Implement Vaati reward drop path |
+| Shrine | Expected Pendant | Reward Source | Current Evidence | Remaining Gate |
+|--------|------------------|---------------|------------------|----------------|
+| S1 Wisdom | 0x39 (Wisdom) | Chest room 0x7A | Source patch + z3ed readback: 0x39 | Runtime pickup/progression |
+| S2 Power | 0x3A (Power) | Chest room 0x73 | Source patch + z3ed readback: 0x3A | Runtime pickup/progression |
+| S3 Courage | 0x38 (Courage) | Vaati boss clear | Not implemented | Implement and runtime-verify Vaati reward |
 
-**2026-06-11: S1/S2 chest data fixed in base ROM** (0x7A big chest → 0x39, 0x73 big chest → 0x3A; verified with `z3ed dungeon-list-chests`). Runtime reward-flow verification still pending. S3 Vaati drop path remains unimplemented.
+`Core/patches.asm` reproducibly patches room 0x7A to 0x39 and room 0x73
+to 0x3A. `z3ed dungeon-list-chests` readback confirms those values in the
+current patched ROM; runtime pickup/progression remains unverified. S3's Vaati
+reward remains unimplemented.
 
 ### Room Ownership Conflict: S2 vs S3 — RESOLVED 2026-02-13
 
@@ -57,12 +60,15 @@ Rooms 0x33, 0x43, 0x53, 0x63 belong to **Shrine of Courage (S3)** per ROM and us
 
 ### D7 Victory Pipeline (Biggest Narrative Gap)
 
-The entire post-D7 flow is unimplemented:
-1. KydrogBoss_Death has no crystal drop, no flag setter, no cutscene
-2. `GameState_FaroreRescued = $03` — setter does not exist anywhere
-3. Message 0x138 (Farore rescue dialogue) — exists in data, no runtime callsite
-4. Post-rescue Hall of Secrets Farore NPC — no states implemented (farore.asm TODO)
-5. Endgame unlock (Sky Islands, Fortress access) — no trigger
+A feature-gated partial scaffold exists, defaults OFF, and is incomplete:
+1. `KydrogBoss_Death` calls `KydrogBoss_Death_FaroreRescueScaffold` only
+   when `!ENABLE_D7_FARORE_RESCUE_SEQUENCE == 1`.
+2. `KydrogBoss_ApplyFaroreRescueProgression` sets the D7 crystal bit and
+   `GameState_FaroreRescued` late in the death timer.
+3. The scaffold uses temporary message 0x138; the
+   crystal-maiden/cutscene/warp handoff is not implemented or runtime-verified.
+4. Post-rescue Hall of Secrets Farore states are not implemented.
+5. The endgame/credits transition is not wired or runtime-verified.
 
 ---
 
@@ -116,7 +122,7 @@ The entire post-D7 flow is unimplemented:
 
 | System | Status | Test Method |
 |--------|--------|-------------|
-| Crystal collection (7 dungeons) | Implemented | Mesen2 SRAM injection |
+| Crystal collection (7 dungeons) | Partial; D7 setter exists only in an OFF-by-default, unverified scaffold | Mesen2 SRAM injection |
 | GetCrystalCount | Complete, untested | Maku Tree test |
 | UpdateMapIcon | Complete, untested | Maku Tree test |
 | SelectReactionMessage | Complete, untested | Maku Tree test |
@@ -142,11 +148,11 @@ The entire post-D7 flow is unimplemented:
 ## Biggest Unknowns (Updated 2026-02-13)
 
 1. ~~D5, D7, S1-S3 have not been assessed~~ **DONE** — assessed 2026-02-13, results above
-2. **No dungeons have been played end-to-end** in the current ROM
+2. **No current-ROM end-to-end dungeon verification is recorded**
 3. **Progression helpers are untested** — the foundation of NPC dialogue gating
 4. **Final boss sequence** — Kydreeok → Temporal Pyramid → Ganondorf three-phase — implementation status unclear
 5. **Mask transformation mechanics** — designed but implementation status unknown
 6. **D7 Farore rescue pipeline** — scaffold exists but post-D7 sequence remains incomplete
-7. **Pendant reward paths are misaligned across S1-S3** — S1/S2 chest data fix + S3 Vaati reward implementation needed
+7. **Pendant reward validation is incomplete** — S1/S2 source patches and readback are correct, but runtime pickup is unverified; S3 Vaati reward path is missing
 8. **S3 Shrine of Courage** — no dungeons.json entry, no boss code, shares entrance with D8, room conflict with S2
 9. **D8 Fortress of Secrets** — still needs full assessment (rooms, boss, connectivity)

--- a/Docs/Planning/release_timeline_2026.md
+++ b/Docs/Planning/release_timeline_2026.md
@@ -1,15 +1,22 @@
 # Oracle of Secrets — Release Timeline 2026
 
-**Updated:** 2026-06-11 (re-baselined after spring pause; RC/release targets unchanged)
-**Current state:** Playable start-to-credits, shipping beta patches to Discord testers
+**Updated:** 2026-07-24 (truth reconciliation; runtime sweep pending)
+**Current state:** Substantial dungeon/content implementation exists, but no
+current-ROM start-to-credits verification is recorded. D1-D8 and S1-S3 require
+an evidence-logged runtime sweep.
 **Target:** Public v1.0 patch (RHDN-quality release)
-**Target RC:** October 2026
-**Target Release:** November 2026
-**Estimated remaining work:** ~160-240 hours (polish + new content) at variable pace
+**Target RC:** October 2026 (provisional; re-evaluate after the runtime sweep)
+**Target Release:** End of 2026 (scope-flexible; provisional)
+**Estimated remaining work:** ~160-240 hours is a planning range; re-estimate
+after the runtime sweep.
 
 ---
 
 ## Re-baseline (2026-06-11)
+
+> **2026-07-24 verification note:** The June checkpoint was not
+> runtime-verified. Calendar dates below are planning targets, not completion
+> evidence.
 
 Work paused early May; phases 1-2 are partially done and Phase 3 has not
 started. Rather than slip the RC, the remaining Phase 1-2 work is compressed
@@ -50,11 +57,14 @@ Notes:
 
 ## What v1.0 Includes
 
-The game is already playable start-to-credits. v1.0 adds polish and the remaining content that makes it the complete vision:
+The repository contains substantial dungeon and story implementation, but the
+current ROM has not been verified start-to-credits. v1.0 requires the runtime
+sweep, critical-path completion, and recorded release gates below.
 
 ### Polish (the game you have now, but better)
 1. **Regression confidence** — verify 21 AI-generated commits haven't broken anything
-2. **D6 Goron Mines quality** — dungeon works but needs to feel finished
+2. **D6 Goron Mines quality** — substantial room/minecart implementation
+   exists; runtime sweep and completion gaps remain
 3. **Boss fight polish** — Kydreeok AI, Octoboss camera, telegraphs/fairness
 4. **Dialogue & narrative** — NPC progression awareness, placeholder cleanup
 
@@ -359,19 +369,11 @@ These are great reasons to keep working on the game after v1.0:
 
 ---
 
-## Progress Tracker
+## Progress Tracking
 
-```
-Phase 1: Regression Confidence   [___________] 0/14 tasks
-Phase 2: D6 + Boss Polish        [___________] 0/13 tasks
-Phase 3: Dream Sequences          [___________] 0/14 tasks
-Phase 4: Sky/Kalyxo/Koroks       [___________] 0/20 tasks
-Phase 5: Dialogue & Narrative     [___________] 0/11 tasks
-Phase 6: RC Build                 [___________] 0/8 tasks
-Phase 7: Release                  [___________] 0/5 tasks
-                                                -------
-                                                0/85 total
-```
+This phase menu is a planning reference, not the canonical task tracker. Track
+live TODO/ACTIVE/DONE state in `Docs/oracle.org`; do not infer completion from
+this document.
 
 ---
 
@@ -384,4 +386,5 @@ Beta patches have been shipping to Discord testers throughout development. Teste
 3. If it's a softlock: check SUBMODE ($7E0011) and SPC timeout ($B010)
 4. If it's "this feels bad": add to the relevant phase's task menu
 
-Tester feedback > this document. If testers say something is fine, trust them.
+Tester feedback is input, not completion evidence. Runtime/gameplay claims
+require a recorded commit, ROM hash, and emulator run.

--- a/Roms/hack_manifest.json
+++ b/Roms/hack_manifest.json
@@ -3677,10 +3677,10 @@
     ]
   },
   "messages": {
-    "description": "Expanded message system. Vanilla messages ($000-$18C) live in bank $0E of the dev ROM \u2014 yaze can edit these. Expanded messages ($18D+) live in bank $2F, owned by ASM. The hook at $0ED436 redirects message reads for expanded IDs. Yaze's message-write CLI can target expanded IDs if it knows the data region bounds.",
+    "description": "Expanded message system. Vanilla messages ($000-$18C) live in bank $0E of the dev ROM \u2014 yaze can edit these. Expanded messages ($18D+) live in bank $2F, owned by ASM. The hook at $0ED436 redirects message reads for expanded IDs. Direct editor or CLI writes to expanded IDs are not durable because the next ASM rebuild replaces bank $2F.",
     "editing_guidance": {
       "vanilla_safe": "Message IDs $000-$18C can be edited in the dev ROM via yaze",
-      "expanded_asm_owned": "Message IDs $18D+ are in bank $2F; edit via Core/message.asm or z3ed message-write CLI",
+      "expanded_asm_owned": "Message IDs $18D+ are in ASM-owned bank $2F; edit Core/message.asm, rebuild with Scripts/Build/build_rom.sh 168, then reopen or reload Roms/oos168x.sfc for inspection. Do not edit the patched ROM directly.",
       "hook_address": "$0ED436 (do not overwrite \u2014 asar patches this)"
     },
     "hook_address": "0x0ED436",

--- a/Scripts/Build/build_rom.sh
+++ b/Scripts/Build/build_rom.sh
@@ -97,6 +97,7 @@ water_restore_pending=0
 water_fill_backup=""
 water_runtime_backup=""
 water_patched_backup=""
+water_patched_existed=0
 restore_flags() {
   if [[ "$flags_modified" != "1" ]]; then
     return 0
@@ -120,10 +121,12 @@ restore_water_transaction() {
   fi
   cp -f "$water_fill_backup" "$repo_root/Dungeons/generated/water_fill_table.asm"
   cp -f "$water_runtime_backup" "$repo_root/Dungeons/generated/water_gate_runtime_tables.asm"
-  if [[ -n "$water_patched_backup" && -f "$water_patched_backup" ]]; then
+  if [[ "$water_patched_existed" == "1" ]]; then
     cp -f "$water_patched_backup" "$patched_rom"
+  else
+    rm -f "$patched_rom"
   fi
-  echo "[*] Restored water includes after failed refresh." >&2
+  echo "[*] Restored water includes and patched ROM after failed refresh." >&2
 }
 cleanup() {
   restore_water_transaction
@@ -350,7 +353,6 @@ for required_room in 25 27; do
     exit 1
   fi
 done
-assemble_rom
 
 water_refresh_requested="${OOS_REFRESH_WATER_TABLES:-0}"
 if [[ -n "${OOS_WATER_FILL_TABLE_ROM:-}" || -n "${OOS_WATER_TABLE_ROM:-}" ]]; then
@@ -373,7 +375,25 @@ if [[ "$water_refresh_requested" == "1" ]]; then
     exit 1
   fi
 
+  # Arm rollback before assemble_rom mutates the patched output. Every explicit
+  # refresh is one transaction spanning initial assembly, candidate generation,
+  # staged-table rebuild, and all later build checks.
   water_tmp_dir="$(mktemp -d "$rom_dir/.water_tables.XXXXXX")"
+  water_fill_backup="$water_tmp_dir/water_fill_table.original.asm"
+  water_runtime_backup="$water_tmp_dir/water_gate_runtime_tables.original.asm"
+  water_patched_backup="$water_tmp_dir/patched_rom.original.sfc"
+  cp -f "$repo_root/Dungeons/generated/water_fill_table.asm" "$water_fill_backup"
+  cp -f "$repo_root/Dungeons/generated/water_gate_runtime_tables.asm" "$water_runtime_backup"
+  if [[ -f "$patched_rom" ]]; then
+    cp -f "$patched_rom" "$water_patched_backup"
+    water_patched_existed=1
+  fi
+  water_restore_pending=1
+fi
+
+assemble_rom
+
+if [[ "$water_refresh_requested" == "1" ]]; then
   candidate_dir="$water_tmp_dir/candidate"
   generate_water_tables "$water_table_rom" "$candidate_dir"
 
@@ -386,14 +406,6 @@ if [[ "$water_refresh_requested" == "1" ]]; then
   fi
 
   if [[ "$water_tables_changed" == "1" ]]; then
-    water_fill_backup="$water_tmp_dir/water_fill_table.original.asm"
-    water_runtime_backup="$water_tmp_dir/water_gate_runtime_tables.original.asm"
-    water_patched_backup="$water_tmp_dir/patched_rom.original.sfc"
-    cp -f "$repo_root/Dungeons/generated/water_fill_table.asm" "$water_fill_backup"
-    cp -f "$repo_root/Dungeons/generated/water_gate_runtime_tables.asm" "$water_runtime_backup"
-    cp -f "$patched_rom" "$water_patched_backup"
-    water_restore_pending=1
-
     cp -f "$candidate_dir/water_fill_table.asm" "$repo_root/Dungeons/generated/water_fill_table.asm"
     cp -f "$candidate_dir/water_gate_runtime_tables.asm" "$repo_root/Dungeons/generated/water_gate_runtime_tables.asm"
     echo "[*] Water table candidates staged; rebuilding once from the base ROM..."

--- a/Scripts/Build/build_rom.sh
+++ b/Scripts/Build/build_rom.sh
@@ -86,6 +86,7 @@ done
 
 repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
 rom_dir="$repo_root/Roms"
+hooks_json="$rom_dir/hooks.json"
 feature_flags_path="$repo_root/Config/feature_flags.asm"
 cd "$repo_root"
 
@@ -98,6 +99,13 @@ water_fill_backup=""
 water_runtime_backup=""
 water_patched_backup=""
 water_patched_existed=0
+water_symbols_backup=""
+water_symbols_existed=0
+water_mlb_backup=""
+water_mlb_existed=0
+water_hooks_backup=""
+water_hooks_existed=0
+hooks_tmp=""
 restore_flags() {
   if [[ "$flags_modified" != "1" ]]; then
     return 0
@@ -115,22 +123,34 @@ restore_flags() {
     echo "[*] Removed temporary feature flags: $feature_flags_path"
   fi
 }
+restore_water_output() {
+  local existed="$1"
+  local backup="$2"
+  local target="$3"
+  if [[ "$existed" == "1" ]]; then
+    cp -f "$backup" "$target"
+  else
+    rm -f "$target"
+  fi
+}
 restore_water_transaction() {
   if [[ "$water_restore_pending" != "1" ]]; then
     return 0
   fi
   cp -f "$water_fill_backup" "$repo_root/Dungeons/generated/water_fill_table.asm"
   cp -f "$water_runtime_backup" "$repo_root/Dungeons/generated/water_gate_runtime_tables.asm"
-  if [[ "$water_patched_existed" == "1" ]]; then
-    cp -f "$water_patched_backup" "$patched_rom"
-  else
-    rm -f "$patched_rom"
-  fi
+  restore_water_output "$water_patched_existed" "$water_patched_backup" "$patched_rom"
+  restore_water_output "$water_symbols_existed" "$water_symbols_backup" "$symbols_path"
+  restore_water_output "$water_mlb_existed" "$water_mlb_backup" "$mlb_path"
+  restore_water_output "$water_hooks_existed" "$water_hooks_backup" "$hooks_json"
   echo "[*] Restored water includes and patched ROM after failed refresh." >&2
 }
 cleanup() {
   restore_water_transaction
   restore_flags
+  if [[ -n "$hooks_tmp" && -f "$hooks_tmp" ]]; then
+    rm -f "$hooks_tmp"
+  fi
   if [[ -n "$water_tmp_dir" && -d "$water_tmp_dir" ]]; then
     rm -rf "$water_tmp_dir"
   fi
@@ -355,6 +375,8 @@ for required_room in 25 27; do
 done
 
 water_refresh_requested="${OOS_REFRESH_WATER_TABLES:-0}"
+water_table_rom=""
+water_table_rom_is_default=0
 if [[ -n "${OOS_WATER_FILL_TABLE_ROM:-}" || -n "${OOS_WATER_TABLE_ROM:-}" ]]; then
   water_refresh_requested=1
 fi
@@ -369,8 +391,12 @@ if [[ -n "${OOS_WATER_FILL_TABLE_ROM:-}" && -n "${OOS_WATER_TABLE_ROM:-}" &&
 fi
 
 if [[ "$water_refresh_requested" == "1" ]]; then
-  water_table_rom="${OOS_WATER_FILL_TABLE_ROM:-${OOS_WATER_TABLE_ROM:-$patched_rom}}"
-  if [[ ! -f "$water_table_rom" ]]; then
+  water_table_rom="${OOS_WATER_FILL_TABLE_ROM:-${OOS_WATER_TABLE_ROM:-}}"
+  if [[ -z "$water_table_rom" ]]; then
+    water_table_rom="$patched_rom"
+    water_table_rom_is_default=1
+  fi
+  if [[ "$water_table_rom_is_default" != "1" && ! -f "$water_table_rom" ]]; then
     echo "ERROR: Water-table authoring ROM not found: $water_table_rom" >&2
     exit 1
   fi
@@ -382,11 +408,26 @@ if [[ "$water_refresh_requested" == "1" ]]; then
   water_fill_backup="$water_tmp_dir/water_fill_table.original.asm"
   water_runtime_backup="$water_tmp_dir/water_gate_runtime_tables.original.asm"
   water_patched_backup="$water_tmp_dir/patched_rom.original.sfc"
+  water_symbols_backup="$water_tmp_dir/symbols.original.sym"
+  water_mlb_backup="$water_tmp_dir/symbols.original.mlb"
+  water_hooks_backup="$water_tmp_dir/hooks.original.json"
   cp -f "$repo_root/Dungeons/generated/water_fill_table.asm" "$water_fill_backup"
   cp -f "$repo_root/Dungeons/generated/water_gate_runtime_tables.asm" "$water_runtime_backup"
   if [[ -f "$patched_rom" ]]; then
     cp -f "$patched_rom" "$water_patched_backup"
     water_patched_existed=1
+  fi
+  if [[ -f "$symbols_path" ]]; then
+    cp -f "$symbols_path" "$water_symbols_backup"
+    water_symbols_existed=1
+  fi
+  if [[ -f "$mlb_path" ]]; then
+    cp -f "$mlb_path" "$water_mlb_backup"
+    water_mlb_existed=1
+  fi
+  if [[ -f "$hooks_json" ]]; then
+    cp -f "$hooks_json" "$water_hooks_backup"
+    water_hooks_existed=1
   fi
   water_restore_pending=1
 fi
@@ -394,6 +435,10 @@ fi
 assemble_rom
 
 if [[ "$water_refresh_requested" == "1" ]]; then
+  if [[ ! -f "$water_table_rom" ]]; then
+    echo "ERROR: Water-table authoring ROM not found after initial assembly: $water_table_rom" >&2
+    exit 1
+  fi
   candidate_dir="$water_tmp_dir/candidate"
   generate_water_tables "$water_table_rom" "$candidate_dir"
 
@@ -453,7 +498,10 @@ if [[ "${OOS_GENERATE_ANNOTATIONS:-0}" == "1" ]]; then
 fi
 
 # Run static analysis if hooks.json exists
-hooks_json="$repo_root/Roms/hooks.json"
+hooks_required=0
+if [[ "${OOS_GENERATE_HOOKS:-0}" == "1" || "${OOS_VALIDATE_HOOKS:-0}" == "1" ]]; then
+  hooks_required=1
+fi
 if [[ -f "$patched_rom" ]]; then
   regen_hooks=0
   if [[ ! -f "$hooks_json" || "${OOS_GENERATE_HOOKS:-0}" == "1" ]]; then
@@ -466,22 +514,52 @@ if [[ -f "$patched_rom" ]]; then
 
   if [[ "$regen_hooks" == "1" ]]; then
     echo "[*] Generating hooks.json..."
-    python3 "$repo_root/Scripts/Generate/generate_hooks_json.py" --root "$repo_root" --output "$hooks_json" --rom "$patched_rom" || true
+    hooks_tmp="$(mktemp "$rom_dir/.hooks.generated.XXXXXX")"
+    if ! python3 "$repo_root/Scripts/Generate/generate_hooks_json.py" \
+      --root "$repo_root" --output "$hooks_tmp" --rom "$patched_rom"; then
+      if [[ "$hooks_required" == "1" ]]; then
+        echo "ERROR: Required hooks.json generation failed." >&2
+        exit 1
+      fi
+      echo "[-] Warning: hooks.json generation failed; continuing without refreshed hook metadata." >&2
+    elif [[ ! -s "$hooks_tmp" ]]; then
+      if [[ "$hooks_required" == "1" ]]; then
+        echo "ERROR: Required hooks.json generation produced no output: $hooks_json" >&2
+        exit 1
+      fi
+      echo "[-] Warning: hooks.json generation produced no output; continuing without refreshed hook metadata." >&2
+    else
+      mv -f "$hooks_tmp" "$hooks_json"
+      hooks_tmp=""
+    fi
+    if [[ -n "$hooks_tmp" ]]; then
+      rm -f "$hooks_tmp"
+      hooks_tmp=""
+    fi
   fi
 fi
 
 # Optional validation: ensure hooks.json matches generator output
 # Set OOS_VALIDATE_ON_BUILD=1 to run hook + sprite checks non-fatally on every build.
 validate_on_build="${OOS_VALIDATE_ON_BUILD:-0}"
-if [[ "${OOS_VALIDATE_HOOKS:-0}" == "1" || "$validate_on_build" == "1" ]]; then
-  if [[ -f "$hooks_json" && -f "$patched_rom" ]]; then
-    if [[ "$validate_on_build" == "1" && "${OOS_VALIDATE_HOOKS:-0}" != "1" ]]; then
-      echo "[*] Validating hooks.json (non-fatal)..."
-    else
-      echo "[*] Validating hooks.json..."
+if [[ "${OOS_VALIDATE_HOOKS:-0}" == "1" ]]; then
+  if [[ ! -s "$hooks_json" || ! -f "$patched_rom" ]]; then
+    echo "ERROR: Required hooks.json validation inputs are missing or empty." >&2
+    exit 1
+  fi
+  echo "[*] Validating hooks.json..."
+  if ! python3 "$repo_root/Scripts/Validate/verify_hooks_json.py" \
+    --root "$repo_root" --rom "$patched_rom" --hooks "$hooks_json"; then
+    echo "ERROR: Required hooks.json validation failed." >&2
+    exit 1
+  fi
+elif [[ "$validate_on_build" == "1" ]]; then
+  if [[ -s "$hooks_json" && -f "$patched_rom" ]]; then
+    echo "[*] Validating hooks.json (non-fatal)..."
+    if ! python3 "$repo_root/Scripts/Validate/verify_hooks_json.py" \
+      --root "$repo_root" --rom "$patched_rom" --hooks "$hooks_json"; then
+      echo "[-] Warning: hooks.json validation failed; continuing because OOS_VALIDATE_ON_BUILD is non-fatal." >&2
     fi
-    python3 "$repo_root/Scripts/Validate/verify_hooks_json.py" \
-      --root "$repo_root" --rom "$patched_rom" --hooks "$hooks_json" || true
   else
     echo "[-] Warning: hooks.json or patched ROM missing; skipping hook validation."
   fi

--- a/Scripts/Generate/generate_hack_manifest.py
+++ b/Scripts/Generate/generate_hack_manifest.py
@@ -675,10 +675,10 @@ def generate_manifest(root: Path, rom_path: Optional[Path] = None) -> dict:
     messages = scan_message_layout(root)
     if messages:
         manifest["messages"] = {
-            "description": "Expanded message system. Vanilla messages ($000-$18C) live in bank $0E of the dev ROM — yaze can edit these. Expanded messages ($18D+) live in bank $2F, owned by ASM. The hook at $0ED436 redirects message reads for expanded IDs. Yaze's message-write CLI can target expanded IDs if it knows the data region bounds.",
+            "description": "Expanded message system. Vanilla messages ($000-$18C) live in bank $0E of the dev ROM — yaze can edit these. Expanded messages ($18D+) live in bank $2F, owned by ASM. The hook at $0ED436 redirects message reads for expanded IDs. Direct editor or CLI writes to expanded IDs are not durable because the next ASM rebuild replaces bank $2F.",
             "editing_guidance": {
                 "vanilla_safe": "Message IDs $000-$18C can be edited in the dev ROM via yaze",
-                "expanded_asm_owned": "Message IDs $18D+ are in bank $2F; edit via Core/message.asm or z3ed message-write CLI",
+                "expanded_asm_owned": "Message IDs $18D+ are in ASM-owned bank $2F; edit Core/message.asm, rebuild with Scripts/Build/build_rom.sh 168, then reopen or reload Roms/oos168x.sfc for inspection. Do not edit the patched ROM directly.",
                 "hook_address": "$0ED436 (do not overwrite — asar patches this)",
             },
             **messages,

--- a/Scripts/Generate/generate_hooks_json.py
+++ b/Scripts/Generate/generate_hooks_json.py
@@ -626,7 +626,9 @@ def main() -> int:
     hooks = scan_hooks(root)
 
     rom_meta = {}
-    rom_path = (root / args.rom).resolve() if not args.rom.is_absolute() else args.rom
+    rom_path = (
+        root / args.rom if not args.rom.is_absolute() else args.rom
+    ).resolve()
     if rom_path.exists():
         rom_meta['path'] = str(rom_path.relative_to(root))
         try:

--- a/Tests/unit/test_generate_hack_manifest.py
+++ b/Tests/unit/test_generate_hack_manifest.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "Scripts" / "Generate"))
+
+from generate_hack_manifest import generate_manifest
+
+
+class HackManifestMessagePolicyTest(unittest.TestCase):
+    def test_expanded_messages_require_asm_rebuild_workflow(self) -> None:
+        generated_messages = generate_manifest(REPO_ROOT)["messages"]
+        tracked_messages = json.loads(
+            (REPO_ROOT / "Roms" / "hack_manifest.json").read_text(encoding="utf-8")
+        )["messages"]
+
+        self.assertEqual(generated_messages, tracked_messages)
+
+        guidance = generated_messages["editing_guidance"]["expanded_asm_owned"]
+        self.assertIn("ASM-owned bank $2F", guidance)
+        self.assertIn("Core/message.asm", guidance)
+        self.assertIn("Scripts/Build/build_rom.sh 168", guidance)
+        self.assertIn("reopen or reload", guidance)
+
+        policy_text = json.dumps(generated_messages)
+        self.assertNotIn("message-write", policy_text)
+        self.assertNotIn("z3ed", policy_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/unit/test_hook_tool_paths.py
+++ b/Tests/unit/test_hook_tool_paths.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from Scripts.Validate.verify_hooks_json import _run_generator
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK_GENERATOR = REPO_ROOT / "Scripts" / "Generate" / "generate_hooks_json.py"
+
+
+class HookToolPathTest(unittest.TestCase):
+    def test_verifier_uses_categorized_generator_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            generator = root / "Scripts" / "Generate" / "generate_hooks_json.py"
+            generator.parent.mkdir(parents=True)
+            generator.write_text(
+                textwrap.dedent(
+                    """\
+                    import argparse
+                    import json
+
+                    parser = argparse.ArgumentParser()
+                    parser.add_argument("--root")
+                    parser.add_argument("--output")
+                    parser.add_argument("--rom")
+                    args = parser.parse_args()
+                    with open(args.output, "w", encoding="utf-8") as handle:
+                        json.dump({"hooks": []}, handle)
+                    """
+                ),
+                encoding="utf-8",
+            )
+            output = root / "generated.json"
+
+            _run_generator(root, root / "rom.sfc", output)
+
+            self.assertEqual(
+                json.loads(output.read_text(encoding="utf-8")), {"hooks": []}
+            )
+            self.assertFalse((root / "scripts" / "generate_hooks_json.py").exists())
+
+    def test_generator_canonicalizes_absolute_rom_path_before_relativizing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            temp_root = Path(tmp)
+            real_root = temp_root / "real"
+            alias_root = temp_root / "alias"
+            rom = real_root / "Roms" / "test.sfc"
+            rom.parent.mkdir(parents=True)
+            rom.write_bytes(b"test-rom")
+            (real_root / "test.asm").write_text("org $008000\nnop\n", encoding="utf-8")
+
+            try:
+                os.symlink(real_root, alias_root, target_is_directory=True)
+            except (OSError, NotImplementedError) as exc:
+                self.skipTest(f"directory symlinks unavailable: {exc}")
+
+            output = temp_root / "hooks.json"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(HOOK_GENERATOR),
+                    "--root",
+                    str(alias_root),
+                    "--rom",
+                    str(alias_root / "Roms" / "test.sfc"),
+                    "--output",
+                    str(output),
+                ],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            metadata = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(metadata["rom"]["path"], "Roms/test.sfc")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/unit/test_hook_tool_paths.py
+++ b/Tests/unit/test_hook_tool_paths.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -14,9 +15,77 @@ from Scripts.Validate.verify_hooks_json import _run_generator
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HOOK_GENERATOR = REPO_ROOT / "Scripts" / "Generate" / "generate_hooks_json.py"
+ROM_SIZE = 0x130000
+
+
+def copy_repo_file(target_root: Path, relative: str) -> None:
+    source = REPO_ROOT / relative
+    target = target_root / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target)
 
 
 class HookToolPathTest(unittest.TestCase):
+    def prepare_build_fixture(
+        self, root: Path, *, generator_source: str, verifier_source: str
+    ) -> tuple[Path, Path]:
+        repo = root / "oracle-of-secrets"
+        repo.mkdir()
+        for relative in (
+            "Scripts/Build/build_rom.sh",
+            "Dungeons/generated/water_fill_table.asm",
+            "Dungeons/generated/water_gate_runtime_tables.asm",
+        ):
+            copy_repo_file(repo, relative)
+
+        scripts = {
+            "Scripts/Build/verify_feature_flags.py": "print('flags ok')\n",
+            "Scripts/Build/check_zscream_overlap.py": "print('overlap ok')\n",
+            "Scripts/Generate/generate_hooks_json.py": generator_source,
+            "Scripts/Validate/verify_hooks_json.py": verifier_source,
+            "Scripts/Validate/validate_sprite_registry.py": "print('sprites ok')\n",
+        }
+        for relative, source in scripts.items():
+            path = repo / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(source, encoding="utf-8")
+
+        rom_dir = repo / "Roms"
+        rom_dir.mkdir()
+        (rom_dir / "oos168.sfc").write_bytes(bytes(ROM_SIZE))
+
+        fake_asar = root / "fake-asar"
+        fake_asar.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        fake_asar.chmod(0o755)
+        return repo, fake_asar
+
+    def run_fixture_build(
+        self, root: Path, repo: Path, fake_asar: Path, **overrides: str
+    ) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env.update(
+            {
+                "OOS_BACKUP_ROOT": str(root / "backups"),
+                "OOS_SKIP_MENU_VALIDATE": "1",
+                "SKIP_ANALYSIS": "1",
+                **overrides,
+            }
+        )
+        return subprocess.run(
+            [
+                str(repo / "Scripts/Build/build_rom.sh"),
+                "168",
+                str(fake_asar),
+                "--no-symbols",
+                "--skip-tests",
+            ],
+            cwd=repo,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
     def test_verifier_uses_categorized_generator_path(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -83,6 +152,101 @@ class HookToolPathTest(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
             metadata = json.loads(output.read_text(encoding="utf-8"))
             self.assertEqual(metadata["rom"]["path"], "Roms/test.sfc")
+
+    def test_hook_generation_failure_is_fatal_only_when_explicit(self) -> None:
+        generator = "import sys\nsys.exit(23)\n"
+        verifier = "print('verification should not run')\n"
+        for explicit in (False, True):
+            with self.subTest(explicit=explicit), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                repo, fake_asar = self.prepare_build_fixture(
+                    root, generator_source=generator, verifier_source=verifier
+                )
+                overrides = {"OOS_GENERATE_HOOKS": "1"} if explicit else {}
+
+                result = self.run_fixture_build(
+                    root, repo, fake_asar, **overrides
+                )
+
+                combined_output = result.stdout + result.stderr
+                if explicit:
+                    self.assertNotEqual(result.returncode, 0, combined_output)
+                    self.assertIn(
+                        "ERROR: Required hooks.json generation failed.",
+                        combined_output,
+                    )
+                else:
+                    self.assertEqual(result.returncode, 0, combined_output)
+                    self.assertIn(
+                        "Warning: hooks.json generation failed", combined_output
+                    )
+                self.assertFalse((repo / "Roms/hooks.json").exists())
+
+    def test_explicit_hook_generation_requires_nonempty_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo, fake_asar = self.prepare_build_fixture(
+                root,
+                generator_source="print('intentionally no output')\n",
+                verifier_source="print('verification should not run')\n",
+            )
+            hooks_path = repo / "Roms/hooks.json"
+            stale_hooks = '{"stale": true}\n'
+            hooks_path.write_text(stale_hooks, encoding="utf-8")
+
+            result = self.run_fixture_build(
+                root, repo, fake_asar, OOS_GENERATE_HOOKS="1"
+            )
+
+            combined_output = result.stdout + result.stderr
+            self.assertNotEqual(result.returncode, 0, combined_output)
+            self.assertIn(
+                "ERROR: Required hooks.json generation produced no output:",
+                combined_output,
+            )
+            self.assertEqual(hooks_path.read_text(encoding="utf-8"), stale_hooks)
+
+    def test_hook_validation_failure_is_fatal_only_when_explicit(self) -> None:
+        generator = textwrap.dedent(
+            """\
+            import argparse
+            from pathlib import Path
+
+            parser = argparse.ArgumentParser()
+            parser.add_argument("--root")
+            parser.add_argument("--output")
+            parser.add_argument("--rom")
+            args = parser.parse_args()
+            Path(args.output).write_text('{"hooks": []}\\n', encoding="utf-8")
+            """
+        )
+        verifier = "import sys\nsys.exit(24)\n"
+        for explicit in (False, True):
+            with self.subTest(explicit=explicit), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                repo, fake_asar = self.prepare_build_fixture(
+                    root, generator_source=generator, verifier_source=verifier
+                )
+                flag = (
+                    {"OOS_VALIDATE_HOOKS": "1"}
+                    if explicit
+                    else {"OOS_VALIDATE_ON_BUILD": "1"}
+                )
+
+                result = self.run_fixture_build(root, repo, fake_asar, **flag)
+
+                combined_output = result.stdout + result.stderr
+                if explicit:
+                    self.assertNotEqual(result.returncode, 0, combined_output)
+                    self.assertIn(
+                        "ERROR: Required hooks.json validation failed.",
+                        combined_output,
+                    )
+                else:
+                    self.assertEqual(result.returncode, 0, combined_output)
+                    self.assertIn(
+                        "Warning: hooks.json validation failed", combined_output
+                    )
 
 
 if __name__ == "__main__":

--- a/Tests/unit/test_water_fill_build_transaction.py
+++ b/Tests/unit/test_water_fill_build_transaction.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from Scripts.Generate import generate_water_fill_table as water_fill
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROM_SIZE = 0x130000
+
+
+def pc_to_lorom(pc: int) -> int:
+    bank = (pc >> 15) & 0x7F
+    address = (pc & 0x7FFF) | 0x8000
+    return (bank << 16) | address
+
+
+def make_authoring_rom(path: Path, rooms: tuple[int, ...]) -> None:
+    data = bytearray(ROM_SIZE)
+    pointer_table = water_fill.snes_to_pc(water_fill.ROOM_POINTER_SNES)
+    for index, room_id in enumerate(rooms):
+        stream_pc = water_fill.CUSTOM_COLLISION_DATA_PC_START + (index * 0x10)
+        pointer_pc = pointer_table + (room_id * 3)
+        data[pointer_pc : pointer_pc + 3] = pc_to_lorom(stream_pc).to_bytes(
+            3, "little"
+        )
+        data[stream_pc : stream_pc + 7] = bytes(
+            (0xF0, 0xF0, room_id, 0x01, 0xF5, 0xFF, 0xFF)
+        )
+    path.write_bytes(data)
+
+
+def copy_repo_file(source_root: Path, target_root: Path, relative: str) -> None:
+    source = source_root / relative
+    target = target_root / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target)
+
+
+class WaterFillBuildTransactionTest(unittest.TestCase):
+    def prepare_fixture(self, root: Path) -> tuple[Path, Path]:
+        repo = root / "oracle-of-secrets"
+        repo.mkdir()
+
+        for relative in (
+            "Scripts/Build/build_rom.sh",
+            "Scripts/Generate/generate_water_fill_table.py",
+            "Scripts/Generate/generate_water_gate_runtime_tables.py",
+            "Dungeons/generated/water_fill_table.asm",
+            "Dungeons/generated/water_gate_runtime_tables.asm",
+        ):
+            copy_repo_file(REPO_ROOT, repo, relative)
+
+        verifier = repo / "Scripts/Build/verify_feature_flags.py"
+        verifier.write_text("print('Feature flags OK (transaction fixture).')\n")
+
+        fake_asar = root / "fake-asar"
+        fake_asar.write_text("#!/bin/sh\nexit 0\n")
+        fake_asar.chmod(0o755)
+
+        rom_dir = repo / "Roms"
+        rom_dir.mkdir()
+        base_data = bytes(ROM_SIZE)
+        patched_data = bytearray(base_data)
+        patched_data[0x40] = 0xA5  # Proves assemble_rom mutates the output.
+        (rom_dir / "oos168.sfc").write_bytes(base_data)
+        (rom_dir / "oos168x.sfc").write_bytes(patched_data)
+        return repo, fake_asar
+
+    def run_refresh(
+        self, root: Path, repo: Path, fake_asar: Path, authoring_rom: Path
+    ) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env.update(
+            {
+                "OOS_BACKUP_ROOT": str(root / "backups"),
+                "OOS_REFRESH_WATER_TABLES": "1",
+                "OOS_SKIP_MENU_VALIDATE": "1",
+                "OOS_WATER_FILL_TABLE_ROM": str(authoring_rom),
+            }
+        )
+        return subprocess.run(
+            [
+                str(repo / "Scripts/Build/build_rom.sh"),
+                "168",
+                str(fake_asar),
+                "--no-symbols",
+                "--skip-tests",
+            ],
+            cwd=repo,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def assert_transaction_restored(
+        self,
+        repo: Path,
+        patched_before: bytes,
+        fill_before: bytes,
+        runtime_before: bytes,
+    ) -> None:
+        self.assertEqual((repo / "Roms/oos168x.sfc").read_bytes(), patched_before)
+        self.assertEqual(
+            (repo / "Dungeons/generated/water_fill_table.asm").read_bytes(),
+            fill_before,
+        )
+        self.assertEqual(
+            (repo / "Dungeons/generated/water_gate_runtime_tables.asm").read_bytes(),
+            runtime_before,
+        )
+
+    def test_failed_generation_restores_patched_rom_and_tracked_tables(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo, fake_asar = self.prepare_fixture(root)
+            authoring_rom = root / "authoring-missing-room27.sfc"
+            make_authoring_rom(authoring_rom, (0x25,))
+
+            patched_before = (repo / "Roms/oos168x.sfc").read_bytes()
+            fill_before = (
+                repo / "Dungeons/generated/water_fill_table.asm"
+            ).read_bytes()
+            runtime_before = (
+                repo / "Dungeons/generated/water_gate_runtime_tables.asm"
+            ).read_bytes()
+
+            result = self.run_refresh(root, repo, fake_asar, authoring_rom)
+
+            combined_output = result.stdout + result.stderr
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(
+                "Required water-fill rooms have no marker tiles: 0x27",
+                combined_output,
+            )
+            self.assertIn(
+                "Restored water includes and patched ROM after failed refresh",
+                combined_output,
+            )
+            self.assert_transaction_restored(
+                repo, patched_before, fill_before, runtime_before
+            )
+
+    def test_failed_post_stage_check_restores_patched_rom_and_tracked_tables(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo, fake_asar = self.prepare_fixture(root)
+            authoring_rom = root / "authoring-complete.sfc"
+            make_authoring_rom(authoring_rom, (0x25, 0x27))
+
+            post_stage_check = repo / "Scripts/Build/check_zscream_overlap.py"
+            post_stage_check.write_text(
+                "import sys\nprint('intentional post-stage failure')\nsys.exit(23)\n"
+            )
+
+            patched_before = (repo / "Roms/oos168x.sfc").read_bytes()
+            fill_before = (
+                repo / "Dungeons/generated/water_fill_table.asm"
+            ).read_bytes()
+            runtime_before = (
+                repo / "Dungeons/generated/water_gate_runtime_tables.asm"
+            ).read_bytes()
+
+            result = self.run_refresh(root, repo, fake_asar, authoring_rom)
+
+            combined_output = result.stdout + result.stderr
+            self.assertEqual(result.returncode, 23, combined_output)
+            self.assertIn("Water table candidates staged", combined_output)
+            self.assertIn("intentional post-stage failure", combined_output)
+            self.assertIn(
+                "Restored water includes and patched ROM after failed refresh",
+                combined_output,
+            )
+            self.assert_transaction_restored(
+                repo, patched_before, fill_before, runtime_before
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/unit/test_water_fill_build_transaction.py
+++ b/Tests/unit/test_water_fill_build_transaction.py
@@ -73,25 +73,47 @@ class WaterFillBuildTransactionTest(unittest.TestCase):
         return repo, fake_asar
 
     def run_refresh(
-        self, root: Path, repo: Path, fake_asar: Path, authoring_rom: Path
+        self,
+        root: Path,
+        repo: Path,
+        fake_asar: Path,
+        authoring_rom: Path | None,
+        *,
+        emit_symbols: bool = False,
+        extra_env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
+        for name in (
+            "OOS_GENERATE_HOOKS",
+            "OOS_VALIDATE_HOOKS",
+            "OOS_VALIDATE_ON_BUILD",
+            "OOS_WATER_FILL_TABLE_ROM",
+            "OOS_WATER_TABLE_ROM",
+        ):
+            env.pop(name, None)
         env.update(
             {
                 "OOS_BACKUP_ROOT": str(root / "backups"),
                 "OOS_REFRESH_WATER_TABLES": "1",
                 "OOS_SKIP_MENU_VALIDATE": "1",
-                "OOS_WATER_FILL_TABLE_ROM": str(authoring_rom),
+                "SKIP_ANALYSIS": "1",
             }
         )
+        if authoring_rom is not None:
+            env["OOS_WATER_FILL_TABLE_ROM"] = str(authoring_rom)
+        if extra_env is not None:
+            env.update(extra_env)
+
+        command = [
+            str(repo / "Scripts/Build/build_rom.sh"),
+            "168",
+            str(fake_asar),
+        ]
+        if not emit_symbols:
+            command.append("--no-symbols")
+        command.append("--skip-tests")
         return subprocess.run(
-            [
-                str(repo / "Scripts/Build/build_rom.sh"),
-                "168",
-                str(fake_asar),
-                "--no-symbols",
-                "--skip-tests",
-            ],
+            command,
             cwd=repo,
             env=env,
             check=False,
@@ -182,6 +204,170 @@ class WaterFillBuildTransactionTest(unittest.TestCase):
             self.assert_transaction_restored(
                 repo, patched_before, fill_before, runtime_before
             )
+
+    def test_refresh_without_authoring_rom_uses_newly_assembled_patched_rom(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo, fake_asar = self.prepare_fixture(root)
+            patched_rom = repo / "Roms/oos168x.sfc"
+            patched_rom.unlink()
+
+            stable_generator = """\
+import argparse
+from pathlib import Path
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--rom", required=True)
+parser.add_argument("--out-asm", required=True)
+args, _ = parser.parse_known_args()
+source = Path(args.rom)
+if not source.is_file():
+    raise SystemExit(f"authoring ROM missing: {source}")
+Path(args.out_asm).write_text(
+    "; stable transaction fixture\\n"
+    "  db $25, $00\\n"
+    "  db $27, $00\\n"
+)
+print(f"stub generated from {source}")
+"""
+            for relative in (
+                "Scripts/Generate/generate_water_fill_table.py",
+                "Scripts/Generate/generate_water_gate_runtime_tables.py",
+            ):
+                (repo / relative).write_text(stable_generator)
+
+            overlap_check = repo / "Scripts/Build/check_zscream_overlap.py"
+            overlap_check.write_text("print('overlap fixture passed')\n")
+
+            result = self.run_refresh(root, repo, fake_asar, None)
+
+            combined_output = result.stdout + result.stderr
+            self.assertEqual(result.returncode, 0, combined_output)
+            self.assertTrue(patched_rom.is_file())
+            self.assertEqual(
+                patched_rom.read_bytes(),
+                (repo / "Roms/oos168.sfc").read_bytes(),
+            )
+            self.assertIn("stub generated from Roms/oos168x.sfc", combined_output)
+            self.assertIn("Water table pair promoted", combined_output)
+
+    def test_failed_overlap_restores_preexisting_symbol_outputs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo, fake_asar = self.prepare_fixture(root)
+            authoring_rom = root / "authoring-complete.sfc"
+            make_authoring_rom(authoring_rom, (0x25, 0x27))
+
+            fake_asar.write_text(
+                """#!/bin/sh
+symbols_path=""
+for arg in "$@"; do
+  case "$arg" in
+    --symbols-path=*) symbols_path="${arg#--symbols-path=}" ;;
+  esac
+done
+if [ -n "$symbols_path" ]; then
+  mkdir -p "$(dirname "$symbols_path")"
+  printf 'new symbols from fake asar\\n' > "$symbols_path"
+fi
+exit 0
+"""
+            )
+
+            export_symbols = repo / "Scripts/Generate/export_symbols.py"
+            export_symbols.write_text(
+                """\
+import sys
+from pathlib import Path
+
+output = Path(sys.argv[sys.argv.index("-o") + 1])
+output.write_text("new labels from export fixture\\n")
+print("symbol export fixture ran")
+"""
+            )
+
+            post_stage_check = repo / "Scripts/Build/check_zscream_overlap.py"
+            post_stage_check.write_text(
+                "import sys\nprint('intentional symbol-stage failure')\nsys.exit(23)\n"
+            )
+
+            symbols_path = repo / "Roms/oos168x.sym"
+            mlb_path = repo / "Roms/oos168x.mlb"
+            symbols_before = b"preexisting symbols\n"
+            mlb_before = b"preexisting labels\n"
+            symbols_path.write_bytes(symbols_before)
+            mlb_path.write_bytes(mlb_before)
+
+            result = self.run_refresh(
+                root, repo, fake_asar, authoring_rom, emit_symbols=True
+            )
+
+            combined_output = result.stdout + result.stderr
+            self.assertEqual(result.returncode, 23, combined_output)
+            self.assertIn("symbol export fixture ran", combined_output)
+            self.assertIn("intentional symbol-stage failure", combined_output)
+            self.assertIn(
+                "Restored water includes and patched ROM after failed refresh",
+                combined_output,
+            )
+            self.assertEqual(symbols_path.read_bytes(), symbols_before)
+            self.assertEqual(mlb_path.read_bytes(), mlb_before)
+
+    def test_failed_explicit_hook_validation_restores_preexisting_hooks(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo, fake_asar = self.prepare_fixture(root)
+            authoring_rom = root / "authoring-complete.sfc"
+            make_authoring_rom(authoring_rom, (0x25, 0x27))
+
+            overlap_check = repo / "Scripts/Build/check_zscream_overlap.py"
+            overlap_check.write_text("print('overlap fixture passed')\n")
+
+            hook_generator = repo / "Scripts/Generate/generate_hooks_json.py"
+            hook_generator.write_text(
+                """\
+import sys
+from pathlib import Path
+
+output = Path(sys.argv[sys.argv.index("--output") + 1])
+output.write_text('{"fixture": "new"}\\n')
+print("hook generation fixture ran")
+"""
+            )
+            hook_verifier = repo / "Scripts/Validate/verify_hooks_json.py"
+            hook_verifier.parent.mkdir(parents=True, exist_ok=True)
+            hook_verifier.write_text(
+                "import sys\nprint('intentional hook validation failure')\nsys.exit(29)\n"
+            )
+
+            hooks_path = repo / "Roms/hooks.json"
+            hooks_before = b'{"fixture": "preexisting"}\n'
+            hooks_path.write_bytes(hooks_before)
+
+            result = self.run_refresh(
+                root,
+                repo,
+                fake_asar,
+                authoring_rom,
+                extra_env={
+                    "OOS_GENERATE_HOOKS": "1",
+                    "OOS_VALIDATE_HOOKS": "1",
+                },
+            )
+
+            combined_output = result.stdout + result.stderr
+            self.assertNotEqual(result.returncode, 0, combined_output)
+            self.assertIn("hook generation fixture ran", combined_output)
+            self.assertIn("intentional hook validation failure", combined_output)
+            self.assertIn(
+                "Restored water includes and patched ROM after failed refresh",
+                combined_output,
+            )
+            self.assertEqual(hooks_path.read_bytes(), hooks_before)
 
 
 if __name__ == "__main__":

--- a/Tests/unit/test_water_fill_generation.py
+++ b/Tests/unit/test_water_fill_generation.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from Scripts.Generate import generate_water_fill_table as water_fill
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GENERATOR = REPO_ROOT / "Scripts/Generate/generate_water_fill_table.py"
+TRACKED_TABLE = REPO_ROOT / "Dungeons/generated/water_fill_table.asm"
+ROM_SIZE = 0x130000
+
+
+def pc_to_lorom(pc: int) -> int:
+    bank = (pc >> 15) & 0x7F
+    address = (pc & 0x7FFF) | 0x8000
+    return (bank << 16) | address
+
+
+def make_marker_rom(path: Path, rooms: tuple[int, ...]) -> None:
+    data = bytearray(ROM_SIZE)
+    pointer_table = water_fill.snes_to_pc(water_fill.ROOM_POINTER_SNES)
+
+    for index, room_id in enumerate(rooms):
+        stream_pc = water_fill.CUSTOM_COLLISION_DATA_PC_START + (index * 0x10)
+        stream_snes = pc_to_lorom(stream_pc)
+        pointer_pc = pointer_table + (room_id * 3)
+        data[pointer_pc : pointer_pc + 3] = stream_snes.to_bytes(3, "little")
+
+        # Single-tile stream: marker, one offset/tile pair, terminator.
+        data[stream_pc : stream_pc + 7] = bytes(
+            (0xF0, 0xF0, room_id, 0x01, 0xF5, 0xFF, 0xFF)
+        )
+
+    path.write_bytes(data)
+
+
+class WaterFillGenerationTest(unittest.TestCase):
+    def run_generator(self, rom: Path, output: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(GENERATOR),
+                "--rom",
+                str(rom),
+                "--out-asm",
+                str(output),
+                "--require-rooms",
+                "0x25,0x27",
+            ],
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_required_rooms_reject_incomplete_authoring_rom(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            rom = root / "authoring.sfc"
+            output = root / "water_fill_table.asm"
+            make_marker_rom(rom, (0x25,))
+
+            result = self.run_generator(rom, output)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(
+                "Required water-fill rooms have no marker tiles: 0x27",
+                result.stderr,
+            )
+            self.assertFalse(output.exists())
+
+    def test_required_rooms_generate_complete_d4_table(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            rom = root / "authoring.sfc"
+            output = root / "water_fill_table.asm"
+            make_marker_rom(rom, (0x25, 0x27))
+
+            result = self.run_generator(rom, output)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            generated = output.read_text()
+            self.assertIn("  db $02", generated)
+            self.assertIn("  db $25, $02 : dw $0009 ; tiles=1", generated)
+            self.assertIn("  db $27, $01 : dw $000C ; tiles=1", generated)
+
+    def test_tracked_release_table_keeps_both_d4_rooms(self) -> None:
+        tracked = TRACKED_TABLE.read_text()
+        self.assertIn("  db $25, $02 : dw $0009 ; tiles=168", tracked)
+        self.assertIn("  db $27, $01 : dw $015A ; tiles=222", tracked)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/unit/test_water_fill_generation.py
+++ b/Tests/unit/test_water_fill_generation.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 import tempfile
 import unittest
+from dataclasses import dataclass
 from pathlib import Path
 
 from Scripts.Generate import generate_water_fill_table as water_fill
@@ -13,6 +15,80 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 GENERATOR = REPO_ROOT / "Scripts/Generate/generate_water_fill_table.py"
 TRACKED_TABLE = REPO_ROOT / "Dungeons/generated/water_fill_table.asm"
 ROM_SIZE = 0x130000
+
+
+@dataclass(frozen=True)
+class ParsedZone:
+    room_id: int
+    mask: int
+    data_offset: int
+    tile_count: int
+    payload: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class ParsedTable:
+    zone_count: int
+    zones: tuple[ParsedZone, ...]
+
+
+def parse_emitted_table(asm: str) -> ParsedTable:
+    """Parse runtime directives, deliberately ignoring all `; tiles=` comments."""
+    header = re.search(
+        r"WaterFillTable_Generated:\s*\{\s*db\s+\$([0-9A-Fa-f]+)(.*?)\}",
+        asm,
+        re.DOTALL,
+    )
+    if not header:
+        raise ValueError("WaterFillTable_Generated block not found")
+
+    zone_count = int(header.group(1), 16)
+    entry_matches = re.findall(
+        r"^\s*db\s+\$([0-9A-Fa-f]+),\s*\$([0-9A-Fa-f]+)\s*"
+        r":\s*dw\s+\$([0-9A-Fa-f]+)",
+        header.group(2),
+        re.MULTILINE,
+    )
+
+    zones: list[ParsedZone] = []
+    for room_raw, mask_raw, offset_raw in entry_matches:
+        room_id = int(room_raw, 16)
+        data_block = re.search(
+            rf"WaterFillData_Room{room_id:02X}:\s*\{{(.*?)\}}",
+            asm,
+            re.DOTALL,
+        )
+        if not data_block:
+            raise ValueError(f"WaterFillData_Room{room_id:02X} block not found")
+
+        count_match = re.search(
+            r"^\s*db\s+\$([0-9A-Fa-f]+)",
+            data_block.group(1),
+            re.MULTILINE,
+        )
+        if not count_match:
+            raise ValueError(f"Room {room_id:02X} count directive not found")
+
+        payload: list[int] = []
+        for values in re.findall(
+            r"^\s*dw\s+([^;\n]+)", data_block.group(1), re.MULTILINE
+        ):
+            payload.extend(
+                int(raw, 16)
+                for raw in re.findall(r"\$([0-9A-Fa-f]+)", values)
+            )
+
+        zones.append(
+            ParsedZone(
+                room_id=room_id,
+                mask=int(mask_raw, 16),
+                data_offset=int(offset_raw, 16),
+                tile_count=int(count_match.group(1), 16),
+                payload=tuple(payload),
+            )
+        )
+
+    return ParsedTable(zone_count=zone_count, zones=tuple(zones))
 
 
 def pc_to_lorom(pc: int) -> int:
@@ -59,20 +135,26 @@ class WaterFillGenerationTest(unittest.TestCase):
         )
 
     def test_required_rooms_reject_incomplete_authoring_rom(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            rom = root / "authoring.sfc"
-            output = root / "water_fill_table.asm"
-            make_marker_rom(rom, (0x25,))
+        cases = (
+            ((0x25,), "0x27"),
+            ((0x27,), "0x25"),
+            ((), "0x25, 0x27"),
+        )
+        for rooms, missing in cases:
+            with self.subTest(rooms=rooms), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                rom = root / "authoring.sfc"
+                output = root / "water_fill_table.asm"
+                make_marker_rom(rom, rooms)
 
-            result = self.run_generator(rom, output)
+                result = self.run_generator(rom, output)
 
-            self.assertNotEqual(result.returncode, 0)
-            self.assertIn(
-                "Required water-fill rooms have no marker tiles: 0x27",
-                result.stderr,
-            )
-            self.assertFalse(output.exists())
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(
+                    f"Required water-fill rooms have no marker tiles: {missing}",
+                    result.stderr,
+                )
+                self.assertFalse(output.exists())
 
     def test_required_rooms_generate_complete_d4_table(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -84,15 +166,36 @@ class WaterFillGenerationTest(unittest.TestCase):
             result = self.run_generator(rom, output)
 
             self.assertEqual(result.returncode, 0, result.stderr)
-            generated = output.read_text()
-            self.assertIn("  db $02", generated)
-            self.assertIn("  db $25, $02 : dw $0009 ; tiles=1", generated)
-            self.assertIn("  db $27, $01 : dw $000C ; tiles=1", generated)
+            table = parse_emitted_table(output.read_text())
+            self.assertEqual(table.zone_count, 2)
+            self.assertEqual(
+                table.zones,
+                (
+                    ParsedZone(0x25, 0x02, 0x0009, 1, (0x0125,)),
+                    ParsedZone(0x27, 0x01, 0x000C, 1, (0x0127,)),
+                ),
+            )
 
     def test_tracked_release_table_keeps_both_d4_rooms(self) -> None:
-        tracked = TRACKED_TABLE.read_text()
-        self.assertIn("  db $25, $02 : dw $0009 ; tiles=168", tracked)
-        self.assertIn("  db $27, $01 : dw $015A ; tiles=222", tracked)
+        table = parse_emitted_table(TRACKED_TABLE.read_text())
+        self.assertEqual(table.zone_count, 2)
+        self.assertEqual(len(table.zones), table.zone_count)
+
+        expected = (
+            (0x25, 0x02, 0x0009, 0xA8),
+            (0x27, 0x01, 0x015A, 0xDE),
+        )
+        running_offset = 1 + (table.zone_count * 4)
+        for zone, (room_id, mask, data_offset, tile_count) in zip(
+            table.zones, expected, strict=True
+        ):
+            self.assertEqual(zone.room_id, room_id)
+            self.assertEqual(zone.mask, mask)
+            self.assertEqual(zone.data_offset, data_offset)
+            self.assertEqual(zone.data_offset, running_offset)
+            self.assertEqual(zone.tile_count, tile_count)
+            self.assertEqual(len(zone.payload), tile_count)
+            running_offset += 1 + (len(zone.payload) * 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This is the integration gate for draft PR #107. It targets
`codex/yaze-prereq-repair` so the prerequisite fixes land on the PR branch
before anything reaches `master`.

It composes the existing work from:

- #108 — portable hook-tool paths
- #109 — D4 water-table generation/rollback
- #111 — expanded-message ownership guidance

It then closes the remaining integration blockers found while reviewing the
combined stack:

- explicit hook generation/validation now fails closed
- hook generation writes to a fresh temporary file and atomically replaces
  `Roms/hooks.json`, so stale output cannot falsely pass
- explicit water refresh works with no pre-existing patched ROM
- late refresh failures restore the patched ROM, water tables, `.sym`, `.mlb`,
  and `hooks.json`
- the manual self-hosted emulator job fails on a missing base ROM, build/hook
  failure, or boot failure
- release/planning docs no longer claim unverified start-to-credits, D6, D7,
  pendant-pickup, or vanilla-message durability status

## Why

PR #107 should not merge alone: the separate prerequisite branches and the
remaining fail-open paths could otherwise create a green-looking build with
missing/stale hook metadata or leave refresh outputs inconsistent after
failure. This PR provides one reviewable, exact-head composition before
updating #107.

## Verification

- `python3 -m unittest -v Tests/unit/test_hook_tool_paths.py Tests/unit/test_generate_hack_manifest.py Tests/unit/test_water_fill_generation.py Tests/unit/test_water_fill_build_transaction.py`
  — 14 passed
- `bash -n Scripts/Build/build_rom.sh`
- `actionlint .github/workflows/test-rom.yml`
- `python3 Scripts/Analysis/lint_docs.py`
- `python3 Scripts/Build/verify_feature_flags.py --root .` — 13/13
- `python3 Scripts/Validate/validate_sprite_registry.py --strict`
- clean disposable Asar build with
  `OOS_GENERATE_HOOKS=1 OOS_VALIDATE_HOOKS=1`
- 551 hooks generated and readback-validated
- regenerated `Roms/hack_manifest.json` matches the tracked manifest
- `z3ed project-bundle-verify --check-rom-hash` — 7 pass / 0 warn / 0 fail
- patched-ROM readback: room `0x7A` = Wisdom (`0x39`), room `0x73` = Power
  (`0x3A`)
- non-strict Oracle smoke check passes; D3 readiness remains false

Verified base SHA-256:
`d289b2408c3ccc312abeadf274f04f475106034fcab8ebff3f307fd229db4799`

Verified patched SHA-256:
`e44d8174fc4c505c2cbdc316664fc5250dd2016a499ad640a07ce5e6a565e4c1`

## Remaining gates

Before PR #107 is merged:

1. Require terminal CI on this exact head.
2. Merge this PR into `codex/yaze-prereq-repair`, then require terminal CI on
   the updated #107 head.
3. Manually dispatch `ROM Tests` with `run_emulator_tests=true` for that exact
   head.
4. Run disposable Yaze Save / Save As / close / reopen / z3ed readback.
5. Keep gameplay acceptance separate: S1/S2 pickup, D4 water roundtrip, D6
   minecart traversal, and D7/endgame are still runtime gates.
