### PR TITLE
feat(editor): add guarded dungeon stream manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,13 @@ Scripts/Build/z3dk_safe_smoke.sh    # safe z3asm smoke build in a temp workspace
 - `Docs/README.md` (documentation index)
 
 `Oracle-of-Secrets.yaze` requires the tracked `Roms/hack_manifest.json` for
-save-policy and build-target safety. Regenerate it after hook/manifest changes
-with `python3 Scripts/Generate/generate_hack_manifest.py --rom Roms/oos168.sfc`.
+save-policy and build-target safety. A successful canonical version-168 build
+without temporary feature-flag overrides refreshes it atomically. To regenerate
+it directly, run
+`python3 Scripts/Generate/generate_hack_manifest.py --rom Roms/oos168.sfc`.
+The manifest derives object, sprite, pot-item, room-header, message-ID, and
+custom-collision bounds from the editable base ROM; the ASM-generated
+WaterFill tail remains blocked.
 
 ## Hook tagging (optional)
 Use `Scripts/Generate/tag_org_hooks.py` to tag org blocks with `@hook` comments and normalize metadata.

--- a/Roms/hack_manifest.json
+++ b/Roms/hack_manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "hack_name": "Oracle of Secrets",
   "hack_version": "dev",
   "generator": "generate_hack_manifest.py",
@@ -24,6 +24,101 @@
     "size": 2097152,
     "dev_rom_sha1": "eaf2ce3d28afa5375adf9c754534a7a98bf06822",
     "dev_rom_size": 2097152
+  },
+  "dungeon_stream_regions": {
+    "objects": {
+      "pointer_table": "0x1F8000",
+      "pointer_count": 296,
+      "pointer_encoding": "long24",
+      "strategy": "copy_on_write",
+      "data_regions": [
+        {
+          "start": "0x0A8000",
+          "end": "0x0AB730"
+        },
+        {
+          "start": "0x1F878A",
+          "end": "0x208000"
+        },
+        {
+          "start": "0x03EB90",
+          "end": "0x048000"
+        },
+        {
+          "start": "0x278000",
+          "end": "0x288000"
+        },
+        {
+          "start": "0x298000",
+          "end": "0x2A8000"
+        }
+      ],
+      "allocation_regions": [
+        {
+          "start": "0x298000",
+          "end": "0x2A8000"
+        }
+      ]
+    },
+    "sprites": {
+      "pointer_table": "0x09D2B2",
+      "pointer_count": 296,
+      "pointer_encoding": "bank16",
+      "pointer_bank": "0x09",
+      "strategy": "copy_on_write",
+      "data_regions": [
+        {
+          "start": "0x09D502",
+          "end": "0x09EC9F"
+        }
+      ],
+      "allocation_regions": [
+        {
+          "start": "0x09D502",
+          "end": "0x09EC9F"
+        }
+      ]
+    },
+    "pot_items": {
+      "pointer_table": "0x01DB69",
+      "pointer_count": 296,
+      "pointer_encoding": "bank16",
+      "pointer_bank": "0x01",
+      "strategy": "repack_all",
+      "data_regions": [
+        {
+          "start": "0x01DDE7",
+          "end": "0x01E6B2"
+        }
+      ],
+      "allocation_regions": [
+        {
+          "start": "0x01DDE7",
+          "end": "0x01E6B2"
+        }
+      ]
+    }
+  },
+  "editor_managed_regions": {
+    "description": "Exact yaze-owned dungeon metadata and custom-collision ranges. The WaterFill tail beginning at $25:E000 remains ASM-owned.",
+    "regions": [
+      {
+        "start": "0x07F61D",
+        "end": "0x07F86D"
+      },
+      {
+        "start": "0x228280",
+        "end": "0x2292B0"
+      },
+      {
+        "start": "0x258090",
+        "end": "0x258408"
+      },
+      {
+        "start": "0x258450",
+        "end": "0x25E000"
+      }
+    ]
   },
   "protected_regions": {
     "description": "Hook addresses within vanilla ROM banks ($00-$1D). Asar patches these on every build, so yaze edits at these addresses are silently overwritten. Yaze should either skip these during save or warn the user.",
@@ -2805,8 +2900,8 @@
         "module": "Masks"
       },
       {
-        "start": "0x1E7F21",
-        "end": "0x1E7F25",
+        "start": "0x1EFF21",
+        "end": "0x1EFF25",
         "size": 4,
         "hook_count": 1,
         "module": "Sprites"

--- a/Scripts/Build/build_rom.sh
+++ b/Scripts/Build/build_rom.sh
@@ -87,6 +87,7 @@ done
 repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
 rom_dir="$repo_root/Roms"
 hooks_json="$rom_dir/hooks.json"
+hack_manifest="$rom_dir/hack_manifest.json"
 feature_flags_path="$repo_root/Config/feature_flags.asm"
 cd "$repo_root"
 
@@ -105,12 +106,19 @@ water_mlb_backup=""
 water_mlb_existed=0
 water_hooks_backup=""
 water_hooks_existed=0
+water_manifest_backup=""
+water_manifest_existed=0
 hooks_tmp=""
+manifest_tmp=""
 restore_flags() {
   if [[ "$flags_modified" != "1" ]]; then
     return 0
   fi
   if [[ "$persist_flags" == "1" ]]; then
+    if [[ -n "$flags_backup" && -f "$flags_backup" ]]; then
+      rm -f "$flags_backup"
+      flags_backup=""
+    fi
     echo "[*] Persisting feature flags: $feature_flags_path"
     return 0
   fi
@@ -143,6 +151,7 @@ restore_water_transaction() {
   restore_water_output "$water_symbols_existed" "$water_symbols_backup" "$symbols_path"
   restore_water_output "$water_mlb_existed" "$water_mlb_backup" "$mlb_path"
   restore_water_output "$water_hooks_existed" "$water_hooks_backup" "$hooks_json"
+  restore_water_output "$water_manifest_existed" "$water_manifest_backup" "$hack_manifest"
   echo "[*] Restored water includes and patched ROM after failed refresh." >&2
 }
 cleanup() {
@@ -150,6 +159,9 @@ cleanup() {
   restore_flags
   if [[ -n "$hooks_tmp" && -f "$hooks_tmp" ]]; then
     rm -f "$hooks_tmp"
+  fi
+  if [[ -n "$manifest_tmp" && -f "$manifest_tmp" ]]; then
+    rm -f "$manifest_tmp"
   fi
   if [[ -n "$water_tmp_dir" && -d "$water_tmp_dir" ]]; then
     rm -rf "$water_tmp_dir"
@@ -411,6 +423,7 @@ if [[ "$water_refresh_requested" == "1" ]]; then
   water_symbols_backup="$water_tmp_dir/symbols.original.sym"
   water_mlb_backup="$water_tmp_dir/symbols.original.mlb"
   water_hooks_backup="$water_tmp_dir/hooks.original.json"
+  water_manifest_backup="$water_tmp_dir/hack_manifest.original.json"
   cp -f "$repo_root/Dungeons/generated/water_fill_table.asm" "$water_fill_backup"
   cp -f "$repo_root/Dungeons/generated/water_gate_runtime_tables.asm" "$water_runtime_backup"
   if [[ -f "$patched_rom" ]]; then
@@ -428,6 +441,10 @@ if [[ "$water_refresh_requested" == "1" ]]; then
   if [[ -f "$hooks_json" ]]; then
     cp -f "$hooks_json" "$water_hooks_backup"
     water_hooks_existed=1
+  fi
+  if [[ -f "$hack_manifest" ]]; then
+    cp -f "$hack_manifest" "$water_manifest_backup"
+    water_manifest_existed=1
   fi
   water_restore_pending=1
 fi
@@ -657,6 +674,50 @@ else
   echo "[*] Skipping smoke tests (runner not found)"
 fi
 
+# Refresh the tracked yaze save-policy manifest only when this build used the
+# canonical project ROM. Portable bundles and explicit OOS_BASE_ROM overrides
+# carry their own path-rewritten manifest and must not be replaced with an
+# absolute machine-local ROM path.
+base_rom_resolved="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$base_rom")"
+default_base_resolved="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$default_base")"
+manifest_refresh_reason=""
+if [[ "$version" != "168" ]]; then
+  manifest_refresh_reason="build version $version is not the project ROM version 168"
+elif [[ "$flags_modified" == "1" && "$persist_flags" != "1" ]]; then
+  manifest_refresh_reason="feature-flag overrides are temporary"
+elif [[ "$base_rom_resolved" != "$default_base_resolved" ]]; then
+  manifest_refresh_reason="the build used a non-canonical base ROM"
+fi
+
+if [[ -z "$manifest_refresh_reason" ]]; then
+  echo "[*] Generating yaze hack manifest..."
+  manifest_tmp="$(mktemp "$rom_dir/.hack_manifest.generated.XXXXXX")"
+  if ! python3 "$repo_root/Scripts/Generate/generate_hack_manifest.py" \
+    --root "$repo_root" \
+    --rom "$base_rom" \
+    --patched-rom "$patched_rom" \
+    --output "$manifest_tmp" \
+    --pretty; then
+    echo "ERROR: Required hack manifest generation failed." >&2
+    exit 1
+  fi
+  if [[ ! -s "$manifest_tmp" ]]; then
+    echo "ERROR: Required hack manifest generation produced no output." >&2
+    exit 1
+  fi
+  mv -f "$manifest_tmp" "$hack_manifest"
+  manifest_tmp=""
+else
+  echo "[*] Preserving existing hack manifest because $manifest_refresh_reason."
+fi
+
+# Commit disk outputs before the optional runtime reload. A reload failure must
+# not roll back a valid ROM/manifest after the emulator may have observed it.
+if [[ "$water_restore_pending" == "1" ]]; then
+  water_restore_pending=0
+  echo "[*] Water table pair promoted."
+fi
+
 if [[ $reload -eq 1 ]]; then
   echo "[*] Sending reload signal to Mesen2..."
   # Simple reload via socket if mesen2_client.py is available
@@ -665,9 +726,4 @@ if [[ $reload -eq 1 ]]; then
   else
     echo "[-] Warning: mesen2_client.py not found, skipping reload."
   fi
-fi
-
-if [[ "$water_restore_pending" == "1" ]]; then
-  water_restore_pending=0
-  echo "[*] Water table pair promoted."
 fi

--- a/Scripts/Generate/generate_hack_manifest.py
+++ b/Scripts/Generate/generate_hack_manifest.py
@@ -95,6 +95,34 @@ SKIP_DIRS = {
     "ZScreamNew",
 }
 
+DUNGEON_ROOM_COUNT = 296
+OBJECT_TABLE_POINTER_OPERAND_PC = 0x874C
+SPRITE_TABLE_POINTER_OPERAND_PC = 0x4C298
+POT_POINTER_TABLE_PC = 0xDB69
+ROOM_HEADER_TABLE_POINTER_OPERAND_PC = 0xB5DD
+ROOM_HEADER_BANK_OPERAND_PC = 0xB5E7
+DUNGEON_MESSAGE_IDS_PC = 0x3F61D
+
+ROOM_HEADER_SIZE = 14
+SPRITE_DATA_END_PC = 0x4EC9F
+POT_DATA_END_PC = 0xE6B2
+CUSTOM_COLLISION_POINTER_TABLE_PC = 0x128090
+CUSTOM_COLLISION_DATA_START_PC = 0x128450
+CUSTOM_COLLISION_DATA_END_PC = 0x12E000
+
+OBJECT_DATA_REGIONS_PC = (
+    (0x50000, 0x53730),
+    (0xF878A, 0x100000),
+    (0x1EB90, 0x20000),
+    (0x138000, 0x140000),
+    (0x148000, 0x150000),
+)
+OBJECT_ALLOCATION_REGIONS_PC = ((0x148000, 0x150000),)
+
+
+class ManifestGenerationError(RuntimeError):
+    """Raised when live ROM data cannot safely produce manifest metadata."""
+
 
 def _should_skip(path: Path) -> bool:
     for part in path.parts:
@@ -525,13 +553,62 @@ def scan_sram_layout(root: Path) -> list[dict]:
 # Protected region computation
 # ---------------------------------------------------------------------------
 
+def _pc_to_snes(pc_address: int) -> int:
+    """Convert an unheadered PC offset to a canonical LoROM SNES address."""
+    if not 0 <= pc_address < 0x400000:
+        raise ManifestGenerationError(
+            f"PC address 0x{pc_address:X} is outside canonical LoROM"
+        )
+    snes_address = (
+        ((pc_address << 1) & 0x7F0000)
+        | (pc_address & 0x7FFF)
+        | 0x8000
+    )
+    if _snes_to_pc(snes_address) != pc_address:
+        raise ManifestGenerationError(
+            f"PC address 0x{pc_address:X} does not round-trip through LoROM"
+        )
+    return snes_address
+
+
+def _snes_to_pc(snes_address: int) -> int:
+    """Convert a mapped LoROM SNES address to an unheadered PC offset."""
+    if not 0 <= snes_address <= 0xFFFFFF:
+        raise ManifestGenerationError(
+            f"SNES address 0x{snes_address:X} is outside 24-bit address space"
+        )
+    canonical = snes_address & 0x7FFFFF
+    bank = (canonical >> 16) & 0x7F
+    if bank in (0x7E, 0x7F) or (canonical & 0xFFFF) < 0x8000:
+        raise ManifestGenerationError(
+            f"SNES address 0x{snes_address:06X} is not mapped LoROM"
+        )
+    return ((canonical & 0x7F0000) >> 1) | (canonical & 0x7FFF)
+
+
+def _canonicalize_hook_address(snes_address: int) -> int:
+    """Map legacy/mirrored hook syntax to a canonical mapped LoROM address."""
+    if not 0 <= snes_address <= 0xFFFFFF:
+        raise ManifestGenerationError(
+            f"hook address 0x{snes_address:X} is outside 24-bit address space"
+        )
+    canonical = snes_address & 0x7FFFFF
+    bank = (canonical >> 16) & 0x7F
+    if bank in (0x7E, 0x7F):
+        raise ManifestGenerationError(
+            f"hook address 0x{snes_address:06X} resolves to WRAM"
+        )
+    pc_address = (
+        ((canonical & 0x7F0000) >> 1)
+        | (canonical & 0x7FFF)
+    )
+    return _pc_to_snes(pc_address)
+
+
 def compute_protected_regions(hooks: list[HookEntry]) -> list[dict]:
-    """Group hooks into contiguous protected address ranges."""
+    """Group hooks into contiguous canonical LoROM protected ranges."""
     if not hooks:
         return []
-
-    # Sort hooks by address
-    sorted_hooks = sorted(hooks, key=lambda h: h.address)
 
     # Estimate size of each hook (conservative: 4 bytes for JML/JSL, 1-8 for data/patch)
     SIZE_ESTIMATE = {
@@ -543,36 +620,42 @@ def compute_protected_regions(hooks: list[HookEntry]) -> list[dict]:
         "patch": 4,   # conservative
     }
 
+    # Manifest v3 requires mapped canonical LoROM endpoints. Some legacy Asar
+    # sources use a low-half spelling (notably $1E7F21); normalize through the
+    # underlying PC offset before sorting and merging.
+    hook_spans = []
+    for hook in hooks:
+        canonical_start = _canonicalize_hook_address(hook.address)
+        start_pc = _snes_to_pc(canonical_start)
+        end_pc = start_pc + SIZE_ESTIMATE.get(hook.kind, 4)
+        hook_spans.append((start_pc, end_pc, hook))
+    hook_spans.sort(key=lambda item: item[0])
+
     regions = []
-    current_start = sorted_hooks[0].address
-    current_end = current_start + SIZE_ESTIMATE.get(sorted_hooks[0].kind, 4)
-    current_hooks = [sorted_hooks[0]]
+    current_start_pc, current_end_pc, first_hook = hook_spans[0]
+    current_hooks = [first_hook]
 
-    for hook in sorted_hooks[1:]:
-        hook_end = hook.address + SIZE_ESTIMATE.get(hook.kind, 4)
-
-        # Merge if within 16 bytes of the previous region (likely related)
-        if hook.address <= current_end + 16:
-            current_end = max(current_end, hook_end)
+    for hook_start_pc, hook_end_pc, hook in hook_spans[1:]:
+        # Merge if within 16 physical ROM bytes of the previous region.
+        if hook_start_pc <= current_end_pc + 16:
+            current_end_pc = max(current_end_pc, hook_end_pc)
             current_hooks.append(hook)
         else:
-            # Emit previous region
             regions.append({
-                "start": f"0x{current_start:06X}",
-                "end": f"0x{current_end:06X}",
-                "size": current_end - current_start,
+                "start": f"0x{_pc_to_snes(current_start_pc):06X}",
+                "end": f"0x{_pc_to_snes(current_end_pc):06X}",
+                "size": current_end_pc - current_start_pc,
                 "hook_count": len(current_hooks),
                 "module": current_hooks[0].module,
             })
-            current_start = hook.address
-            current_end = hook_end
+            current_start_pc = hook_start_pc
+            current_end_pc = hook_end_pc
             current_hooks = [hook]
 
-    # Emit last region
     regions.append({
-        "start": f"0x{current_start:06X}",
-        "end": f"0x{current_end:06X}",
-        "size": current_end - current_start,
+        "start": f"0x{_pc_to_snes(current_start_pc):06X}",
+        "end": f"0x{_pc_to_snes(current_end_pc):06X}",
+        "size": current_end_pc - current_start_pc,
         "hook_count": len(current_hooks),
         "module": current_hooks[0].module,
     })
@@ -581,10 +664,493 @@ def compute_protected_regions(hooks: list[HookEntry]) -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
+# Live dungeon layout extraction
+# ---------------------------------------------------------------------------
+
+def _require_rom_span(data: bytes, pc_address: int, size: int, label: str) -> None:
+    if pc_address < 0 or size < 0 or pc_address + size > len(data):
+        raise ManifestGenerationError(
+            f"{label} PC span [0x{pc_address:X}, 0x{pc_address + size:X}) "
+            f"exceeds editable ROM size 0x{len(data):X}"
+        )
+
+
+def _read_u8(data: bytes, pc_address: int, label: str) -> int:
+    _require_rom_span(data, pc_address, 1, label)
+    return data[pc_address]
+
+
+def _read_u16_le(data: bytes, pc_address: int, label: str) -> int:
+    _require_rom_span(data, pc_address, 2, label)
+    return data[pc_address] | (data[pc_address + 1] << 8)
+
+
+def _read_u24_le(data: bytes, pc_address: int, label: str) -> int:
+    _require_rom_span(data, pc_address, 3, label)
+    return (
+        data[pc_address]
+        | (data[pc_address + 1] << 8)
+        | (data[pc_address + 2] << 16)
+    )
+
+
+def _snes_hex(address: int) -> str:
+    return f"0x{address:06X}"
+
+
+def _pc_range_json(start: int, end: int) -> dict[str, str]:
+    if start >= end:
+        raise ManifestGenerationError(
+            f"invalid empty/reversed PC range [0x{start:X}, 0x{end:X})"
+        )
+    return {
+        "start": _snes_hex(_pc_to_snes(start)),
+        "end": _snes_hex(_pc_to_snes(end)),
+    }
+
+
+def _range_contains(outer: tuple[int, int], inner: tuple[int, int]) -> bool:
+    return outer[0] <= inner[0] and inner[1] <= outer[1]
+
+
+def _validate_regions(
+    data: bytes,
+    stream_name: str,
+    data_regions: tuple[tuple[int, int], ...],
+    allocation_regions: tuple[tuple[int, int], ...],
+) -> None:
+    if not data_regions or not allocation_regions:
+        raise ManifestGenerationError(
+            f"{stream_name} data/allocation regions must be non-empty"
+        )
+
+    sorted_data = sorted(data_regions)
+    for index, (start, end) in enumerate(sorted_data):
+        if start >= end:
+            raise ManifestGenerationError(
+                f"{stream_name} data region {index} is empty or reversed"
+            )
+        _require_rom_span(
+            data, start, end - start, f"{stream_name} data region {index}"
+        )
+        _pc_to_snes(start)
+        _pc_to_snes(end)
+        if index and start < sorted_data[index - 1][1]:
+            raise ManifestGenerationError(
+                f"{stream_name} data regions overlap at PC 0x{start:X}"
+            )
+
+    sorted_allocations = sorted(allocation_regions)
+    for index, allocation in enumerate(sorted_allocations):
+        start, end = allocation
+        if start >= end:
+            raise ManifestGenerationError(
+                f"{stream_name} allocation region {index} is empty or reversed"
+            )
+        if not any(_range_contains(region, allocation) for region in data_regions):
+            raise ManifestGenerationError(
+                f"{stream_name} allocation [0x{start:X}, 0x{end:X}) is not "
+                "contained in a data region"
+            )
+        if index and start < sorted_allocations[index - 1][1]:
+            raise ManifestGenerationError(
+                f"{stream_name} allocation regions overlap at PC 0x{start:X}"
+            )
+
+
+def _pointer_pc_in_regions(
+    pointer_pc: int,
+    regions: tuple[tuple[int, int], ...],
+) -> bool:
+    return any(start <= pointer_pc < end for start, end in regions)
+
+
+def _validate_disjoint_named_ranges(
+    ranges: list[tuple[str, int, int]],
+    description: str,
+) -> None:
+    sorted_ranges = sorted(ranges, key=lambda item: (item[1], item[2]))
+    for previous, current in zip(sorted_ranges, sorted_ranges[1:]):
+        if current[1] < previous[2]:
+            raise ManifestGenerationError(
+                f"{description} overlap: {previous[0]} "
+                f"[0x{previous[1]:X}, 0x{previous[2]:X}) conflicts with "
+                f"{current[0]} [0x{current[1]:X}, 0x{current[2]:X})"
+            )
+
+
+def _derive_dungeon_stream_regions(data: bytes) -> dict:
+    # Objects use a 24-bit pointer table whose address is itself stored in a
+    # long operand. Every live pointer must remain inside a known OOS pool.
+    object_table_raw = _read_u24_le(
+        data,
+        OBJECT_TABLE_POINTER_OPERAND_PC,
+        "object pointer-table operand",
+    )
+    object_table_pc = _snes_to_pc(object_table_raw)
+    object_table_snes = _pc_to_snes(object_table_pc)
+    object_table_size = DUNGEON_ROOM_COUNT * 3
+    _require_rom_span(
+        data, object_table_pc, object_table_size, "object pointer table"
+    )
+    _validate_regions(
+        data,
+        "objects",
+        OBJECT_DATA_REGIONS_PC,
+        OBJECT_ALLOCATION_REGIONS_PC,
+    )
+    for room_id in range(DUNGEON_ROOM_COUNT):
+        pointer_pc = object_table_pc + room_id * 3
+        object_pointer = _read_u24_le(
+            data, pointer_pc, f"object pointer for room 0x{room_id:03X}"
+        )
+        object_data_pc = _snes_to_pc(object_pointer)
+        if not _pointer_pc_in_regions(object_data_pc, OBJECT_DATA_REGIONS_PC):
+            raise ManifestGenerationError(
+                f"object pointer for room 0x{room_id:03X} resolves to PC "
+                f"0x{object_data_pc:X}, outside declared object data regions"
+            )
+
+    # Sprites use two-byte pointers fixed to bank $09.
+    sprite_table_low = _read_u16_le(
+        data,
+        SPRITE_TABLE_POINTER_OPERAND_PC,
+        "sprite pointer-table operand",
+    )
+    sprite_table_snes = 0x090000 | sprite_table_low
+    sprite_table_pc = _snes_to_pc(sprite_table_snes)
+    sprite_table_size = DUNGEON_ROOM_COUNT * 2
+    _require_rom_span(
+        data, sprite_table_pc, sprite_table_size, "sprite pointer table"
+    )
+    sprite_pointers_pc: list[int] = []
+    for room_id in range(DUNGEON_ROOM_COUNT):
+        pointer_low = _read_u16_le(
+            data,
+            sprite_table_pc + room_id * 2,
+            f"sprite pointer for room 0x{room_id:03X}",
+        )
+        sprite_pointers_pc.append(_snes_to_pc(0x090000 | pointer_low))
+    sprite_data_start_pc = sprite_table_pc + sprite_table_size
+    minimum_sprite_pointer_pc = min(sprite_pointers_pc)
+    if minimum_sprite_pointer_pc < sprite_data_start_pc:
+        raise ManifestGenerationError(
+            f"minimum sprite pointer PC 0x{minimum_sprite_pointer_pc:X} "
+            f"precedes pointer-table end PC 0x{sprite_data_start_pc:X}"
+        )
+    sprite_regions = ((sprite_data_start_pc, SPRITE_DATA_END_PC),)
+    _validate_regions(data, "sprites", sprite_regions, sprite_regions)
+    for room_id, pointer_pc in enumerate(sprite_pointers_pc):
+        if not _pointer_pc_in_regions(pointer_pc, sprite_regions):
+            raise ManifestGenerationError(
+                f"sprite pointer for room 0x{room_id:03X} resolves to PC "
+                f"0x{pointer_pc:X}, outside sprite data region"
+            )
+
+    # Pot-item pointers are a fixed table of bank-$01 words. Yaze inventories
+    # all 296 entries, so an unmapped word must fail here rather than produce a
+    # manifest that its allocator cannot consume.
+    pot_table_size = DUNGEON_ROOM_COUNT * 2
+    _require_rom_span(
+        data, POT_POINTER_TABLE_PC, pot_table_size, "pot-item pointer table"
+    )
+    pot_pointers_pc: list[int] = []
+    for room_id in range(DUNGEON_ROOM_COUNT):
+        pointer_low = _read_u16_le(
+            data,
+            POT_POINTER_TABLE_PC + room_id * 2,
+            f"pot-item pointer for room 0x{room_id:03X}",
+        )
+        if pointer_low < 0x8000:
+            raise ManifestGenerationError(
+                f"pot-item pointer for room 0x{room_id:03X} is unmapped "
+                f"bank-$01 value 0x{pointer_low:04X}"
+            )
+        pot_pointers_pc.append(_snes_to_pc(0x010000 | pointer_low))
+    pot_data_start_pc = min(pot_pointers_pc)
+    pot_regions = ((pot_data_start_pc, POT_DATA_END_PC),)
+    _validate_regions(data, "pot_items", pot_regions, pot_regions)
+    for room_id, pointer_pc in enumerate(pot_pointers_pc):
+        if not _pointer_pc_in_regions(pointer_pc, pot_regions):
+            raise ManifestGenerationError(
+                f"pot-item pointer for room 0x{room_id:03X} resolves to PC "
+                f"0x{pointer_pc:X}, outside pot-item data region"
+            )
+
+    stream_data_regions = {
+        "objects": OBJECT_DATA_REGIONS_PC,
+        "sprites": sprite_regions,
+        "pot_items": pot_regions,
+    }
+    pointer_tables = {
+        "objects": (object_table_pc, object_table_pc + object_table_size),
+        "sprites": (sprite_table_pc, sprite_table_pc + sprite_table_size),
+        "pot_items": (
+            POT_POINTER_TABLE_PC,
+            POT_POINTER_TABLE_PC + pot_table_size,
+        ),
+    }
+    occupied_ranges = [
+        (f"{name}.pointer_table", start, end)
+        for name, (start, end) in pointer_tables.items()
+    ]
+    occupied_ranges.extend(
+        (f"{name}.data_regions[{index}]", start, end)
+        for name, ranges in stream_data_regions.items()
+        for index, (start, end) in enumerate(ranges)
+    )
+    occupied_ranges.extend(
+        (
+            ("objects.pointer_source", OBJECT_TABLE_POINTER_OPERAND_PC,
+             OBJECT_TABLE_POINTER_OPERAND_PC + 3),
+            ("sprites.pointer_source", SPRITE_TABLE_POINTER_OPERAND_PC,
+             SPRITE_TABLE_POINTER_OPERAND_PC + 2),
+            ("objects.door_pointer_table", 0xF83C0,
+             0xF83C0 + DUNGEON_ROOM_COUNT * 3),
+        )
+    )
+    _validate_disjoint_named_ranges(
+        occupied_ranges, "dungeon stream pointer/data ranges"
+    )
+    _validate_disjoint_named_ranges(
+        [
+            ("objects.allocation_regions[0]", *OBJECT_ALLOCATION_REGIONS_PC[0]),
+            ("sprites.allocation_regions[0]", *sprite_regions[0]),
+            ("pot_items.allocation_regions[0]", *pot_regions[0]),
+        ],
+        "dungeon stream allocation ranges",
+    )
+
+    return {
+        "objects": {
+            "pointer_table": _snes_hex(object_table_snes),
+            "pointer_count": DUNGEON_ROOM_COUNT,
+            "pointer_encoding": "long24",
+            "strategy": "copy_on_write",
+            "data_regions": [
+                _pc_range_json(start, end)
+                for start, end in OBJECT_DATA_REGIONS_PC
+            ],
+            "allocation_regions": [
+                _pc_range_json(start, end)
+                for start, end in OBJECT_ALLOCATION_REGIONS_PC
+            ],
+        },
+        "sprites": {
+            "pointer_table": _snes_hex(_pc_to_snes(sprite_table_pc)),
+            "pointer_count": DUNGEON_ROOM_COUNT,
+            "pointer_encoding": "bank16",
+            "pointer_bank": "0x09",
+            "strategy": "copy_on_write",
+            "data_regions": [
+                _pc_range_json(start, end) for start, end in sprite_regions
+            ],
+            "allocation_regions": [
+                _pc_range_json(start, end) for start, end in sprite_regions
+            ],
+        },
+        "pot_items": {
+            "pointer_table": _snes_hex(_pc_to_snes(POT_POINTER_TABLE_PC)),
+            "pointer_count": DUNGEON_ROOM_COUNT,
+            "pointer_encoding": "bank16",
+            "pointer_bank": "0x01",
+            "strategy": "repack_all",
+            "data_regions": [
+                _pc_range_json(start, end) for start, end in pot_regions
+            ],
+            "allocation_regions": [
+                _pc_range_json(start, end) for start, end in pot_regions
+            ],
+        },
+    }
+
+
+def _find_custom_collision_stream_end(
+    data: bytes, room_id: int, start_pc: int
+) -> int:
+    """Return the exclusive end of one validated custom-collision stream."""
+    def require_stream_span(cursor: int, size: int, label: str) -> None:
+        if (
+            cursor < CUSTOM_COLLISION_DATA_START_PC
+            or size < 0
+            or cursor + size > CUSTOM_COLLISION_DATA_END_PC
+        ):
+            raise ManifestGenerationError(
+                f"{label} for room 0x{room_id:03X} crosses reserved "
+                f"WaterFill data at PC 0x{CUSTOM_COLLISION_DATA_END_PC:X}"
+            )
+        _require_rom_span(data, cursor, size, label)
+
+    cursor = start_pc
+    single_tile_mode = False
+    while cursor < CUSTOM_COLLISION_DATA_END_PC:
+        require_stream_span(cursor, 2, "custom collision stream word")
+        word = _read_u16_le(
+            data, cursor, f"custom collision stream for room 0x{room_id:03X}"
+        )
+        cursor += 2
+        if word == 0xFFFF:
+            return cursor
+        if word == 0xF0F0:
+            single_tile_mode = True
+            continue
+        if single_tile_mode:
+            require_stream_span(cursor, 1, "custom collision tile")
+            cursor += 1
+            continue
+
+        require_stream_span(cursor, 2, "custom collision rectangle dimensions")
+        width = _read_u8(
+            data, cursor, f"custom collision width for room 0x{room_id:03X}"
+        )
+        height = _read_u8(
+            data,
+            cursor + 1,
+            f"custom collision height for room 0x{room_id:03X}",
+        )
+        cursor += 2
+        payload_size = width * height
+        require_stream_span(cursor, payload_size, "custom collision rectangle")
+        cursor += payload_size
+
+    raise ManifestGenerationError(
+        f"custom collision stream for room 0x{room_id:03X} is unterminated "
+        f"before reserved WaterFill data at PC 0x{CUSTOM_COLLISION_DATA_END_PC:X}"
+    )
+
+
+def _derive_editor_managed_regions(data: bytes) -> dict:
+    """Derive exact dungeon metadata/collision ranges that yaze owns."""
+    header_table_raw = _read_u24_le(
+        data,
+        ROOM_HEADER_TABLE_POINTER_OPERAND_PC,
+        "room-header pointer-table operand",
+    )
+    header_table_pc = _snes_to_pc(header_table_raw)
+    header_table_size = DUNGEON_ROOM_COUNT * 2
+    _require_rom_span(
+        data, header_table_pc, header_table_size, "room-header pointer table"
+    )
+    header_bank = _read_u8(
+        data, ROOM_HEADER_BANK_OPERAND_PC, "room-header data bank operand"
+    )
+    header_starts_pc: list[int] = []
+    for room_id in range(DUNGEON_ROOM_COUNT):
+        pointer_low = _read_u16_le(
+            data,
+            header_table_pc + room_id * 2,
+            f"room-header pointer for room 0x{room_id:03X}",
+        )
+        if pointer_low < 0x8000:
+            raise ManifestGenerationError(
+                f"room-header pointer for room 0x{room_id:03X} is unmapped "
+                f"value 0x{pointer_low:04X}"
+            )
+        header_pc = _snes_to_pc((header_bank << 16) | pointer_low)
+        _require_rom_span(
+            data,
+            header_pc,
+            ROOM_HEADER_SIZE,
+            f"room header for room 0x{room_id:03X}",
+        )
+        header_starts_pc.append(header_pc)
+    room_header_region = (
+        min(header_starts_pc),
+        max(start + ROOM_HEADER_SIZE for start in header_starts_pc),
+    )
+
+    message_ids_region = (
+        DUNGEON_MESSAGE_IDS_PC,
+        DUNGEON_MESSAGE_IDS_PC + DUNGEON_ROOM_COUNT * 2,
+    )
+    _require_rom_span(
+        data,
+        message_ids_region[0],
+        message_ids_region[1] - message_ids_region[0],
+        "dungeon message-ID table",
+    )
+
+    collision_pointer_table_end = (
+        CUSTOM_COLLISION_POINTER_TABLE_PC + DUNGEON_ROOM_COUNT * 3
+    )
+    _require_rom_span(
+        data,
+        CUSTOM_COLLISION_POINTER_TABLE_PC,
+        collision_pointer_table_end - CUSTOM_COLLISION_POINTER_TABLE_PC,
+        "custom-collision pointer table",
+    )
+    _require_rom_span(
+        data,
+        CUSTOM_COLLISION_DATA_START_PC,
+        CUSTOM_COLLISION_DATA_END_PC - CUSTOM_COLLISION_DATA_START_PC,
+        "custom-collision data region",
+    )
+    for room_id in range(DUNGEON_ROOM_COUNT):
+        raw_pointer = _read_u24_le(
+            data,
+            CUSTOM_COLLISION_POINTER_TABLE_PC + room_id * 3,
+            f"custom-collision pointer for room 0x{room_id:03X}",
+        )
+        if raw_pointer == 0:
+            continue
+        collision_pc = _snes_to_pc(raw_pointer)
+        if not (
+            CUSTOM_COLLISION_DATA_START_PC
+            <= collision_pc
+            < CUSTOM_COLLISION_DATA_END_PC
+        ):
+            raise ManifestGenerationError(
+                f"custom-collision pointer for room 0x{room_id:03X} resolves "
+                f"to PC 0x{collision_pc:X}, outside the editor-owned region"
+            )
+        _find_custom_collision_stream_end(data, room_id, collision_pc)
+
+    named_regions = [
+        ("dungeon_message_ids", *message_ids_region),
+        ("room_headers", *room_header_region),
+        (
+            "custom_collision_pointers",
+            CUSTOM_COLLISION_POINTER_TABLE_PC,
+            collision_pointer_table_end,
+        ),
+        (
+            "custom_collision_data",
+            CUSTOM_COLLISION_DATA_START_PC,
+            CUSTOM_COLLISION_DATA_END_PC,
+        ),
+    ]
+    _validate_disjoint_named_ranges(named_regions, "editor-managed regions")
+
+    return {
+        "description": (
+            "Exact yaze-owned dungeon metadata and custom-collision ranges. "
+            "The WaterFill tail beginning at $25:E000 remains ASM-owned."
+        ),
+        "regions": [
+            _pc_range_json(start, end)
+            for _, start, end in sorted(named_regions, key=lambda item: item[1])
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
 # Main manifest generation
 # ---------------------------------------------------------------------------
 
-def generate_manifest(root: Path, rom_path: Optional[Path] = None) -> dict:
+def _manifest_path(root: Path, path: Path) -> str:
+    """Return a portable repo-relative path when possible."""
+    resolved_path = path.resolve()
+    resolved_root = root.resolve()
+    if resolved_path.is_relative_to(resolved_root):
+        return str(resolved_path.relative_to(resolved_root))
+    return str(resolved_path)
+
+
+def generate_manifest(
+    root: Path,
+    rom_path: Optional[Path] = None,
+    patched_rom_path: Optional[Path] = None,
+) -> dict:
     """Generate the complete hack manifest."""
     import hashlib
 
@@ -596,17 +1162,22 @@ def generate_manifest(root: Path, rom_path: Optional[Path] = None) -> dict:
 
     # Build manifest sections
     manifest: dict = {
-        "manifest_version": 2,
+        "manifest_version": 3,
         "hack_name": "Oracle of Secrets",
         "hack_version": "dev",
         "generator": "generate_hack_manifest.py",
     }
 
+    editable_rom_path = rom_path or (root / "Roms" / "oos168.sfc")
+    selected_patched_rom_path = (
+        patched_rom_path or (root / "Roms" / "oos168x.sfc")
+    )
+
     # Build pipeline model
     manifest["build_pipeline"] = {
         "description": "Yaze edits the dev ROM; asar patches it to produce the patched ROM. They share the same base file.",
-        "dev_rom": "Roms/oos168.sfc",
-        "patched_rom": "Roms/oos168x.sfc",
+        "dev_rom": _manifest_path(root, editable_rom_path),
+        "patched_rom": _manifest_path(root, selected_patched_rom_path),
         "assembler": "asar",
         "entry_point": "Oracle_main.asm",
         "build_script": "Scripts/Build/build_rom.sh",
@@ -619,26 +1190,40 @@ def generate_manifest(root: Path, rom_path: Optional[Path] = None) -> dict:
         "key_insight": "Hook addresses in the dev ROM are overwritten by asar on every build. Yaze edits to these addresses are silently lost. The manifest identifies which addresses belong to which layer.",
     }
 
-    # ROM metadata (patched ROM for verification, dev ROM for editing)
+    # ROM metadata always identifies the editable base. The patched output is
+    # build-only and is deliberately not accepted as the project hash.
     rom_meta: dict = {}
-    if rom_path and rom_path.exists():
-        rom_meta["path"] = str(rom_path.relative_to(root)) if rom_path.is_relative_to(root) else str(rom_path)
+    editable_rom_data: Optional[bytes] = None
+    if rom_path is not None:
+        if not rom_path.is_file():
+            raise ManifestGenerationError(
+                f"editable ROM does not exist: {rom_path}"
+            )
         try:
-            data = rom_path.read_bytes()
-            rom_meta["sha1"] = hashlib.sha1(data).hexdigest()
-            rom_meta["size"] = len(data)
-        except Exception:
-            pass
-    # Also hash the dev ROM if it exists
-    dev_rom_path = root / "Roms" / "oos168.sfc"
-    if dev_rom_path.exists():
-        try:
-            dev_data = dev_rom_path.read_bytes()
-            rom_meta["dev_rom_sha1"] = hashlib.sha1(dev_data).hexdigest()
-            rom_meta["dev_rom_size"] = len(dev_data)
-        except Exception:
-            pass
+            editable_rom_data = rom_path.read_bytes()
+        except OSError as exc:
+            raise ManifestGenerationError(
+                f"unable to read editable ROM {rom_path}: {exc}"
+            ) from exc
+        editable_sha1 = hashlib.sha1(editable_rom_data).hexdigest()
+        rom_meta = {
+            "path": _manifest_path(root, rom_path),
+            "sha1": editable_sha1,
+            "size": len(editable_rom_data),
+            "dev_rom_sha1": editable_sha1,
+            "dev_rom_size": len(editable_rom_data),
+        }
     manifest["rom"] = rom_meta
+
+    # Allocation metadata and v3 editor exemptions are derived from the live
+    # editable ROM, never from the Asar-patched output.
+    if editable_rom_data is not None:
+        manifest["dungeon_stream_regions"] = _derive_dungeon_stream_regions(
+            editable_rom_data
+        )
+        manifest["editor_managed_regions"] = _derive_editor_managed_regions(
+            editable_rom_data
+        )
 
     # Protected regions — these are hook addresses in VANILLA banks.
     # Asar overwrites these on build, so yaze edits here are lost.
@@ -731,6 +1316,29 @@ def generate_manifest(root: Path, rom_path: Optional[Path] = None) -> dict:
     return manifest
 
 
+def _write_manifest_atomic(output: Path, content: str) -> None:
+    """Replace the generated manifest without exposing a partial JSON file."""
+    import os
+    import tempfile
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    file_descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{output.name}.",
+        dir=output.parent,
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(file_descriptor, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary_path, 0o644)
+        os.replace(temporary_path, output)
+    except BaseException:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Generate hack manifest for yaze editor integration"
@@ -750,8 +1358,14 @@ def main() -> int:
     parser.add_argument(
         "--rom",
         type=Path,
+        default=Path("Roms/oos168.sfc"),
+        help="Editable/base ROM used for metadata and live dungeon layout",
+    )
+    parser.add_argument(
+        "--patched-rom",
+        type=Path,
         default=Path("Roms/oos168x.sfc"),
-        help="ROM path for metadata (optional)",
+        help="Patched build output path recorded in build_pipeline",
     )
     parser.add_argument(
         "--pretty",
@@ -770,13 +1384,20 @@ def main() -> int:
     output = (root / args.output).resolve() if not args.output.is_absolute() else args.output
 
     rom_path = (root / args.rom).resolve() if not args.rom.is_absolute() else args.rom
-    if not rom_path.exists():
-        rom_path = None
+    patched_rom_path = (
+        (root / args.patched_rom).resolve()
+        if not args.patched_rom.is_absolute()
+        else args.patched_rom
+    )
 
-    manifest = generate_manifest(root, rom_path)
+    try:
+        manifest = generate_manifest(root, rom_path, patched_rom_path)
+    except ManifestGenerationError as exc:
+        print(f"error: cannot generate hack manifest: {exc}", file=sys.stderr)
+        return 1
 
     indent = None if args.compact else 2
-    output.write_text(json.dumps(manifest, indent=indent) + "\n")
+    _write_manifest_atomic(output, json.dumps(manifest, indent=indent) + "\n")
 
     summary = manifest["summary"]
     print(f"Hack manifest written to {output}")

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -24,7 +24,7 @@ This repo has accumulated scripts over time. The goal is to keep a small “gold
 
 ## Generation / Validation
 - Hook metadata: `Scripts/Generate/generate_hooks_json.py`, `Scripts/Validate/verify_hooks_json.py`
-- Required tracked yaze manifest: `python3 Scripts/Generate/generate_hack_manifest.py --rom Roms/oos168.sfc`
+- Required tracked yaze manifest (also refreshed atomically by canonical builds): `python3 Scripts/Generate/generate_hack_manifest.py --rom Roms/oos168.sfc`
 - Yaze project registry outputs (iOS/Mac Oracle dashboards): `Scripts/Analysis/extract_resource_labels.py` → `Docs/Dev/Planning/oracle_resource_labels.json`
 - Yaze story events export (iOS/Mac Oracle dashboards): `Scripts/Analysis/extract_story_events.py` → `Docs/Dev/Planning/story_events.json`
 - Symbol export: `Scripts/Generate/export_symbols.py`

--- a/Tests/unit/test_generate_hack_manifest.py
+++ b/Tests/unit/test_generate_hack_manifest.py
@@ -2,18 +2,80 @@ from __future__ import annotations
 
 import json
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "Scripts" / "Generate"))
 
-from generate_hack_manifest import generate_manifest
+from generate_hack_manifest import (
+    ManifestGenerationError,
+    generate_manifest,
+)
+
+
+ROM_SIZE = 0x200000
+ROOM_COUNT = 296
+
+
+def pc_to_snes(pc_address: int) -> int:
+    return (
+        ((pc_address << 1) & 0x7F0000)
+        | (pc_address & 0x7FFF)
+        | 0x8000
+    )
+
+
+def write_u16(data: bytearray, offset: int, value: int) -> None:
+    data[offset : offset + 2] = value.to_bytes(2, "little")
+
+
+def write_u24(data: bytearray, offset: int, value: int) -> None:
+    data[offset : offset + 3] = value.to_bytes(3, "little")
+
+
+def make_layout_rom(path: Path) -> bytearray:
+    data = bytearray(ROM_SIZE)
+
+    object_table_pc = 0xF8000
+    write_u24(data, 0x874C, pc_to_snes(object_table_pc))
+    for room_id in range(ROOM_COUNT):
+        write_u24(
+            data,
+            object_table_pc + room_id * 3,
+            pc_to_snes(0x50000),
+        )
+
+    sprite_table_pc = 0x4D2B2
+    write_u16(data, 0x4C298, pc_to_snes(sprite_table_pc) & 0xFFFF)
+    for room_id in range(ROOM_COUNT):
+        write_u16(data, sprite_table_pc + room_id * 2, 0xD502)
+
+    for room_id in range(ROOM_COUNT):
+        write_u16(data, 0xDB69 + room_id * 2, 0xDDE7)
+
+    header_table_pc = 0x110000
+    write_u24(data, 0xB5DD, pc_to_snes(header_table_pc))
+    data[0xB5E7] = 0x22
+    for room_id in range(ROOM_COUNT):
+        write_u16(
+            data,
+            header_table_pc + room_id * 2,
+            0x8280 + room_id * 14,
+        )
+
+    write_u24(data, 0x128090, pc_to_snes(0x128450))
+    data[0x128450 : 0x128454] = b"\xF0\xF0\xFF\xFF"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    return data
 
 
 class HackManifestMessagePolicyTest(unittest.TestCase):
     def test_expanded_messages_require_asm_rebuild_workflow(self) -> None:
-        generated_messages = generate_manifest(REPO_ROOT)["messages"]
+        generated = generate_manifest(REPO_ROOT)
+        generated_messages = generated["messages"]
         tracked_messages = json.loads(
             (REPO_ROOT / "Roms" / "hack_manifest.json").read_text(encoding="utf-8")
         )["messages"]
@@ -29,6 +91,179 @@ class HackManifestMessagePolicyTest(unittest.TestCase):
         policy_text = json.dumps(generated_messages)
         self.assertNotIn("message-write", policy_text)
         self.assertNotIn("z3ed", policy_text)
+
+        self.assertEqual(generated["manifest_version"], 3)
+        for region in generated["protected_regions"]["regions"]:
+            for endpoint in ("start", "end"):
+                address = int(region[endpoint], 16)
+                self.assertGreaterEqual(address & 0xFFFF, 0x8000)
+        self.assertTrue(
+            any(
+                region["start"] == "0x1EFF21"
+                and region["end"] == "0x1EFF25"
+                for region in generated["protected_regions"]["regions"]
+            )
+        )
+
+
+class HackManifestDungeonLayoutTest(unittest.TestCase):
+    def generate_synthetic(
+        self,
+        mutate=None,
+    ) -> dict:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            rom = root / "Roms" / "oos168.sfc"
+            data = make_layout_rom(rom)
+            if mutate is not None:
+                mutate(data)
+                rom.write_bytes(data)
+            return generate_manifest(
+                root,
+                rom,
+                root / "Roms" / "oos168x.sfc",
+            )
+
+    def test_emits_exact_live_dungeon_layout_and_editor_ranges(self) -> None:
+        manifest = self.generate_synthetic()
+
+        self.assertEqual(manifest["manifest_version"], 3)
+        self.assertEqual(
+            manifest["rom"]["path"],
+            "Roms/oos168.sfc",
+        )
+        self.assertEqual(
+            set(manifest["dungeon_stream_regions"]),
+            {"objects", "sprites", "pot_items"},
+        )
+        self.assertEqual(
+            manifest["dungeon_stream_regions"],
+            {
+                "objects": {
+                    "pointer_table": "0x1F8000",
+                    "pointer_count": ROOM_COUNT,
+                    "pointer_encoding": "long24",
+                    "strategy": "copy_on_write",
+                    "data_regions": [
+                        {"start": "0x0A8000", "end": "0x0AB730"},
+                        {"start": "0x1F878A", "end": "0x208000"},
+                        {"start": "0x03EB90", "end": "0x048000"},
+                        {"start": "0x278000", "end": "0x288000"},
+                        {"start": "0x298000", "end": "0x2A8000"},
+                    ],
+                    "allocation_regions": [
+                        {"start": "0x298000", "end": "0x2A8000"}
+                    ],
+                },
+                "sprites": {
+                    "pointer_table": "0x09D2B2",
+                    "pointer_count": ROOM_COUNT,
+                    "pointer_encoding": "bank16",
+                    "pointer_bank": "0x09",
+                    "strategy": "copy_on_write",
+                    "data_regions": [
+                        {"start": "0x09D502", "end": "0x09EC9F"}
+                    ],
+                    "allocation_regions": [
+                        {"start": "0x09D502", "end": "0x09EC9F"}
+                    ],
+                },
+                "pot_items": {
+                    "pointer_table": "0x01DB69",
+                    "pointer_count": ROOM_COUNT,
+                    "pointer_encoding": "bank16",
+                    "pointer_bank": "0x01",
+                    "strategy": "repack_all",
+                    "data_regions": [
+                        {"start": "0x01DDE7", "end": "0x01E6B2"}
+                    ],
+                    "allocation_regions": [
+                        {"start": "0x01DDE7", "end": "0x01E6B2"}
+                    ],
+                },
+            },
+        )
+        self.assertEqual(
+            manifest["editor_managed_regions"]["regions"],
+            [
+                {"start": "0x07F61D", "end": "0x07F86D"},
+                {"start": "0x228280", "end": "0x2292B0"},
+                {"start": "0x258090", "end": "0x258408"},
+                {"start": "0x258450", "end": "0x25E000"},
+            ],
+        )
+        self.assertNotIn(
+            {"start": "0x25E000", "end": "0x268000"},
+            manifest["editor_managed_regions"]["regions"],
+        )
+
+    def test_invalid_live_pointers_fail_closed(self) -> None:
+        def make_collision_terminator_straddle(data: bytearray) -> None:
+            write_u24(data, 0x128090, pc_to_snes(0x12DFFF))
+            data[0x12DFFF : 0x12E001] = b"\xFF\xFF"
+
+        mutations = {
+            "object": (
+                lambda data: write_u24(data, 0xF8000, pc_to_snes(0x60000)),
+                "object pointer for room 0x000",
+            ),
+            "sprite": (
+                lambda data: write_u16(data, 0x4D2B2, 0xD501),
+                "minimum sprite pointer",
+            ),
+            "pot": (
+                lambda data: write_u16(data, 0xDB69, 0x7000),
+                "pot-item pointer for room 0x000 is unmapped",
+            ),
+            "collision": (
+                lambda data: write_u24(data, 0x128090, pc_to_snes(0x12E000)),
+                "custom-collision pointer for room 0x000",
+            ),
+            "collision_tail_straddle": (
+                make_collision_terminator_straddle,
+                "crosses reserved WaterFill data",
+            ),
+        }
+        for name, (mutate, expected) in mutations.items():
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(ManifestGenerationError, expected):
+                    self.generate_synthetic(mutate)
+
+    def test_missing_explicit_editable_rom_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            missing = root / "Roms" / "missing.sfc"
+            with self.assertRaisesRegex(
+                ManifestGenerationError,
+                "editable ROM does not exist",
+            ):
+                generate_manifest(root, missing)
+
+    def test_generation_is_deterministic_for_same_editable_rom(self) -> None:
+        first = self.generate_synthetic()
+        second = self.generate_synthetic()
+        self.assertEqual(first, second)
+
+    def test_tracked_manifest_has_v3_daily_driver_contract(self) -> None:
+        tracked = json.loads(
+            (REPO_ROOT / "Roms" / "hack_manifest.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertEqual(tracked["manifest_version"], 3)
+        self.assertEqual(
+            set(tracked["dungeon_stream_regions"]),
+            {"objects", "sprites", "pot_items"},
+        )
+        self.assertEqual(
+            tracked["editor_managed_regions"]["regions"],
+            [
+                {"start": "0x07F61D", "end": "0x07F86D"},
+                {"start": "0x228280", "end": "0x2292B0"},
+                {"start": "0x258090", "end": "0x258408"},
+                {"start": "0x258450", "end": "0x25E000"},
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/Tests/unit/test_hook_tool_paths.py
+++ b/Tests/unit/test_hook_tool_paths.py
@@ -16,6 +16,15 @@ from Scripts.Validate.verify_hooks_json import _run_generator
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HOOK_GENERATOR = REPO_ROOT / "Scripts" / "Generate" / "generate_hooks_json.py"
 ROM_SIZE = 0x130000
+SUCCESSFUL_HOOK_GENERATOR = textwrap.dedent(
+    """\
+    import sys
+    from pathlib import Path
+
+    output = Path(sys.argv[sys.argv.index("--output") + 1])
+    output.write_text('{"hooks": []}\\n', encoding="utf-8")
+    """
+)
 
 
 def copy_repo_file(target_root: Path, relative: str) -> None:
@@ -41,7 +50,26 @@ class HookToolPathTest(unittest.TestCase):
         scripts = {
             "Scripts/Build/verify_feature_flags.py": "print('flags ok')\n",
             "Scripts/Build/check_zscream_overlap.py": "print('overlap ok')\n",
+            "Scripts/Build/set_feature_flags.py": textwrap.dedent(
+                """\
+                import sys
+                from pathlib import Path
+
+                output = Path(sys.argv[sys.argv.index("--output") + 1])
+                output.parent.mkdir(parents=True, exist_ok=True)
+                output.write_text("!ENABLE_FIXTURE = 1\\n", encoding="utf-8")
+                """
+            ),
             "Scripts/Generate/generate_hooks_json.py": generator_source,
+            "Scripts/Generate/generate_hack_manifest.py": textwrap.dedent(
+                """\
+                import sys
+                from pathlib import Path
+
+                output = Path(sys.argv[sys.argv.index("--output") + 1])
+                output.write_text('{"fixture": "manifest"}\\n', encoding="utf-8")
+                """
+            ),
             "Scripts/Validate/verify_hooks_json.py": verifier_source,
             "Scripts/Validate/validate_sprite_registry.py": "print('sprites ok')\n",
         }
@@ -60,7 +88,14 @@ class HookToolPathTest(unittest.TestCase):
         return repo, fake_asar
 
     def run_fixture_build(
-        self, root: Path, repo: Path, fake_asar: Path, **overrides: str
+        self,
+        root: Path,
+        repo: Path,
+        fake_asar: Path,
+        *,
+        version: str = "168",
+        extra_args: tuple[str, ...] = (),
+        **overrides: str,
     ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env.update(
@@ -74,8 +109,9 @@ class HookToolPathTest(unittest.TestCase):
         return subprocess.run(
             [
                 str(repo / "Scripts/Build/build_rom.sh"),
-                "168",
+                version,
                 str(fake_asar),
+                *extra_args,
                 "--no-symbols",
                 "--skip-tests",
             ],
@@ -247,6 +283,221 @@ class HookToolPathTest(unittest.TestCase):
                     self.assertIn(
                         "Warning: hooks.json validation failed", combined_output
                     )
+
+    def test_manifest_generation_failure_preserves_tracked_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo, fake_asar = self.prepare_build_fixture(
+                root,
+                generator_source=SUCCESSFUL_HOOK_GENERATOR,
+                verifier_source="print('hooks valid')\n",
+            )
+            manifest_path = repo / "Roms" / "hack_manifest.json"
+            original_manifest = '{"fixture": "preexisting"}\n'
+            manifest_path.write_text(original_manifest, encoding="utf-8")
+            (repo / "Scripts/Generate/generate_hack_manifest.py").write_text(
+                "import sys\nsys.exit(31)\n",
+                encoding="utf-8",
+            )
+            reload_marker = root / "reload-ran"
+            mesen_client = repo / "Scripts/Mesen2/mesen2_client.py"
+            mesen_client.parent.mkdir(parents=True, exist_ok=True)
+            mesen_client.write_text(
+                "from pathlib import Path\n"
+                f"Path({str(reload_marker)!r}).write_text('ran')\n",
+                encoding="utf-8",
+            )
+
+            result = self.run_fixture_build(
+                root,
+                repo,
+                fake_asar,
+                extra_args=("--reload",),
+            )
+
+            combined_output = result.stdout + result.stderr
+            self.assertNotEqual(result.returncode, 0, combined_output)
+            self.assertIn(
+                "ERROR: Required hack manifest generation failed.",
+                combined_output,
+            )
+            self.assertEqual(
+                manifest_path.read_text(encoding="utf-8"),
+                original_manifest,
+            )
+            self.assertFalse(reload_marker.exists())
+
+    def test_external_base_rom_preserves_portable_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo, fake_asar = self.prepare_build_fixture(
+                root,
+                generator_source=SUCCESSFUL_HOOK_GENERATOR,
+                verifier_source="print('hooks valid')\n",
+            )
+            external_base = root / "portable-bundle-rom.sfc"
+            external_base.write_bytes((repo / "Roms/oos168.sfc").read_bytes())
+            manifest_path = repo / "Roms/hack_manifest.json"
+            portable_manifest = '{"rom": {"path": "rom"}}\n'
+            manifest_path.write_text(portable_manifest, encoding="utf-8")
+
+            result = self.run_fixture_build(
+                root,
+                repo,
+                fake_asar,
+                OOS_BASE_ROM=str(external_base),
+            )
+
+            combined_output = result.stdout + result.stderr
+            self.assertEqual(result.returncode, 0, combined_output)
+            self.assertIn(
+                "Preserving existing hack manifest because the build used a "
+                "non-canonical base ROM.",
+                combined_output,
+            )
+            self.assertEqual(
+                manifest_path.read_text(encoding="utf-8"),
+                portable_manifest,
+            )
+
+    def test_temporary_feature_flags_do_not_replace_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo, fake_asar = self.prepare_build_fixture(
+                root,
+                generator_source=SUCCESSFUL_HOOK_GENERATOR,
+                verifier_source="print('hooks valid')\n",
+            )
+            manifest_path = repo / "Roms/hack_manifest.json"
+            original_manifest = '{"fixture": "default-flags"}\n'
+            manifest_path.write_text(original_manifest, encoding="utf-8")
+
+            result = self.run_fixture_build(
+                root,
+                repo,
+                fake_asar,
+                extra_args=("--enable", "fixture"),
+            )
+
+            combined_output = result.stdout + result.stderr
+            self.assertEqual(result.returncode, 0, combined_output)
+            self.assertIn(
+                "Preserving existing hack manifest because feature-flag "
+                "overrides are temporary.",
+                combined_output,
+            )
+            self.assertEqual(
+                manifest_path.read_text(encoding="utf-8"),
+                original_manifest,
+            )
+            self.assertFalse((repo / "Config/feature_flags.asm").exists())
+
+    def test_non_project_rom_version_does_not_replace_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo, fake_asar = self.prepare_build_fixture(
+                root,
+                generator_source=SUCCESSFUL_HOOK_GENERATOR,
+                verifier_source="print('hooks valid')\n",
+            )
+            (repo / "Roms/oos167.sfc").write_bytes(
+                (repo / "Roms/oos168.sfc").read_bytes()
+            )
+            manifest_path = repo / "Roms/hack_manifest.json"
+            original_manifest = '{"fixture": "version-168"}\n'
+            manifest_path.write_text(original_manifest, encoding="utf-8")
+
+            result = self.run_fixture_build(
+                root,
+                repo,
+                fake_asar,
+                version="167",
+            )
+
+            combined_output = result.stdout + result.stderr
+            self.assertEqual(result.returncode, 0, combined_output)
+            self.assertIn(
+                "Preserving existing hack manifest because build version 167 "
+                "is not the project ROM version 168.",
+                combined_output,
+            )
+            self.assertEqual(
+                manifest_path.read_text(encoding="utf-8"),
+                original_manifest,
+            )
+
+    def test_persisted_feature_flags_remove_temporary_backup(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo, fake_asar = self.prepare_build_fixture(
+                root,
+                generator_source=SUCCESSFUL_HOOK_GENERATOR,
+                verifier_source="print('hooks valid')\n",
+            )
+            feature_flags = repo / "Config/feature_flags.asm"
+            feature_flags.parent.mkdir(parents=True)
+            feature_flags.write_text("!ENABLE_FIXTURE = 0\n", encoding="utf-8")
+
+            result = self.run_fixture_build(
+                root,
+                repo,
+                fake_asar,
+                extra_args=("--enable", "fixture", "--persist-flags"),
+            )
+
+            combined_output = result.stdout + result.stderr
+            self.assertEqual(result.returncode, 0, combined_output)
+            self.assertEqual(
+                feature_flags.read_text(encoding="utf-8"),
+                "!ENABLE_FIXTURE = 1\n",
+            )
+            self.assertEqual(
+                list((repo / "Roms").glob(".feature_flags_backup.*")),
+                [],
+            )
+
+    def test_reload_failure_happens_after_manifest_commit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo, fake_asar = self.prepare_build_fixture(
+                root,
+                generator_source=SUCCESSFUL_HOOK_GENERATOR,
+                verifier_source="print('hooks valid')\n",
+            )
+            manifest_path = repo / "Roms/hack_manifest.json"
+            manifest_path.write_text(
+                '{"fixture": "preexisting"}\n',
+                encoding="utf-8",
+            )
+            mesen_client = repo / "Scripts/Mesen2/mesen2_client.py"
+            mesen_client.parent.mkdir(parents=True, exist_ok=True)
+            mesen_client.write_text(
+                "import sys\n"
+                "from pathlib import Path\n"
+                "root = Path(__file__).resolve().parents[2]\n"
+                "manifest = (root / 'Roms/hack_manifest.json').read_text()\n"
+                "print(f'reload observed: {manifest.strip()}')\n"
+                "sys.exit(44)\n",
+                encoding="utf-8",
+            )
+
+            result = self.run_fixture_build(
+                root,
+                repo,
+                fake_asar,
+                extra_args=("--reload",),
+            )
+
+            combined_output = result.stdout + result.stderr
+            self.assertEqual(result.returncode, 44, combined_output)
+            self.assertIn(
+                'reload observed: {"fixture": "manifest"}',
+                combined_output,
+            )
+            self.assertEqual(
+                manifest_path.read_text(encoding="utf-8"),
+                '{"fixture": "manifest"}\n',
+            )
 
 
 if __name__ == "__main__":

--- a/Tests/unit/test_water_fill_build_transaction.py
+++ b/Tests/unit/test_water_fill_build_transaction.py
@@ -59,6 +59,19 @@ class WaterFillBuildTransactionTest(unittest.TestCase):
         verifier = repo / "Scripts/Build/verify_feature_flags.py"
         verifier.write_text("print('Feature flags OK (transaction fixture).')\n")
 
+        manifest_generator = (
+            repo / "Scripts/Generate/generate_hack_manifest.py"
+        )
+        manifest_generator.write_text(
+            """\
+import sys
+from pathlib import Path
+
+output = Path(sys.argv[sys.argv.index("--output") + 1])
+output.write_text('{"fixture": "manifest"}\\n', encoding="utf-8")
+"""
+        )
+
         fake_asar = root / "fake-asar"
         fake_asar.write_text("#!/bin/sh\nexit 0\n")
         fake_asar.chmod(0o755)
@@ -368,6 +381,51 @@ print("hook generation fixture ran")
                 combined_output,
             )
             self.assertEqual(hooks_path.read_bytes(), hooks_before)
+
+    def test_failed_manifest_generation_preserves_manifest_and_rolls_back_water(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo, fake_asar = self.prepare_fixture(root)
+            authoring_rom = root / "authoring-complete.sfc"
+            make_authoring_rom(authoring_rom, (0x25, 0x27))
+
+            overlap_check = repo / "Scripts/Build/check_zscream_overlap.py"
+            overlap_check.write_text("print('overlap fixture passed')\n")
+
+            manifest_path = repo / "Roms/hack_manifest.json"
+            manifest_before = b'{"fixture": "preexisting"}\n'
+            manifest_path.write_bytes(manifest_before)
+            (repo / "Scripts/Generate/generate_hack_manifest.py").write_text(
+                "import sys\nprint('intentional manifest failure')\nsys.exit(37)\n"
+            )
+
+            patched_before = (repo / "Roms/oos168x.sfc").read_bytes()
+            fill_before = (
+                repo / "Dungeons/generated/water_fill_table.asm"
+            ).read_bytes()
+            runtime_before = (
+                repo / "Dungeons/generated/water_gate_runtime_tables.asm"
+            ).read_bytes()
+
+            result = self.run_refresh(root, repo, fake_asar, authoring_rom)
+
+            combined_output = result.stdout + result.stderr
+            self.assertNotEqual(result.returncode, 0, combined_output)
+            self.assertIn("intentional manifest failure", combined_output)
+            self.assertIn(
+                "ERROR: Required hack manifest generation failed.",
+                combined_output,
+            )
+            self.assertIn(
+                "Restored water includes and patched ROM after failed refresh",
+                combined_output,
+            )
+            self.assert_transaction_restored(
+                repo, patched_before, fill_before, runtime_before
+            )
+            self.assertEqual(manifest_path.read_bytes(), manifest_before)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Stacked on #107. This adds the Oracle-side manifest contract needed by current Yaze dungeon stream allocation and guarded saves.

- derive all 296 object, sprite, and pot-item stream layouts from the editable `oos168.sfc`
- emit manifest v3 exact editor-managed ranges for dungeon message IDs, room headers, and custom collision
- keep the ASM-generated WaterFill tail blocked rather than silently allowing a save that the next build can overwrite
- canonicalize protected LoROM endpoints required by Yaze manifest v3
- regenerate `Roms/hack_manifest.json` atomically at the successful canonical version-168 build boundary
- preserve portable/external-ROM manifests, non-168 manifests, and manifests from temporary feature-flag builds
- include manifest state in water-table rollback and keep emulator reload explicitly post-commit

## Why

The project uses `write_policy=block`, but the existing v2 manifest had no dungeon allocator metadata and treated custom-collision bank `$25` as wholly ASM-owned. That left current Yaze unable to relocate variable-length dungeon streams safely and blocked legitimate collision saves. The build also had no fail-closed path for keeping the tracked manifest synchronized with the editable ROM.

## Verification

- `Tests.unit.test_generate_hack_manifest`: 6/6 passed
- `Tests.unit.test_hook_tool_paths`: 11/11 passed
- `Tests.unit.test_water_fill_build_transaction`: 6/6 passed
- generator skip/export bundle companion tests: 9/9 passed
- `bash -n Scripts/Build/build_rom.sh`
- clean Asar build: `build_rom.sh 168 --no-symbols --skip-tests`
- regenerated manifest exactly matches the tracked artifact, SHA-256 `11efac9d2c95585788d46325dcf3b7bbb61d8a649b1ee896d8b4642b1933d222`
- current Yaze `origin/master` (`3831282619aefc65956d4b0fc6265ba0f032fb5e`): 35/35 focused manifest/CLI tests passed
- real-ROM `dungeon-stream-plan`: objects, sprites, and pot items each report 296/296 valid slots, zero issues, and zero overlaps

## Intentional boundary

WaterFill `$25:E000+` remains ASM-owned and blocked until its editor-to-generated-ASM synchronization path is made durable. The legacy label-only `org $1E7F21` is canonicalized to `$1EFF21` for v3 compatibility; removing that stale source directive can be a separate cleanup.
