### PR TITLE
fix(manifest): derive ownership from reachable ASM

### DIFF
--- a/.github/workflows/manifest-tests.yml
+++ b/.github/workflows/manifest-tests.yml
@@ -1,0 +1,33 @@
+name: Manifest Generator Tests
+
+on:
+  push:
+    paths:
+      - 'Scripts/**'
+      - '.github/workflows/manifest-tests.yml'
+  pull_request:
+    paths:
+      - 'Scripts/**'
+      - '.github/workflows/manifest-tests.yml'
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Python manifest tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run manifest generator tests
+        run: >-
+          python3 -m unittest discover
+          -s Scripts/Generate/tests
+          -p 'test_generate_hack_manifest.py'
+          -v

--- a/.github/workflows/manifest-tests.yml
+++ b/.github/workflows/manifest-tests.yml
@@ -3,11 +3,13 @@ name: Manifest Generator Tests
 on:
   push:
     paths:
-      - 'Scripts/**'
+      - '**/*.asm'
+      - 'Scripts/Generate/**'
       - '.github/workflows/manifest-tests.yml'
   pull_request:
     paths:
-      - 'Scripts/**'
+      - '**/*.asm'
+      - 'Scripts/Generate/**'
       - '.github/workflows/manifest-tests.yml'
   workflow_dispatch:
 

--- a/Scripts/Generate/generate_hack_manifest.py
+++ b/Scripts/Generate/generate_hack_manifest.py
@@ -100,13 +100,6 @@ INCSRC_RE = re.compile(
     re.IGNORECASE,
 )
 
-SKIP_DIRS = {
-    ".git", ".context", ".claude", ".cursor",
-    "Roms", "Docs", "docs",
-    "build", "bin", "obj", "Tools", "tools", "tests", "node_modules",
-    "ZScreamNew",
-}
-
 MANIFEST_ENTRY_POINT = Path("Oracle_main.asm")
 DUNGEON_ROOM_COUNT = 296
 ROOM_HEADER_POINTER_PC = 0xB5DD
@@ -117,13 +110,6 @@ DUNGEON_MESSAGE_IDS_PC = 0x3F61D
 
 class ManifestGenerationError(RuntimeError):
     """Raised when source or ROM evidence cannot safely define ownership."""
-
-
-def _should_skip(path: Path) -> bool:
-    for part in path.parts:
-        if part in SKIP_DIRS:
-            return True
-    return False
 
 
 def _parse_incsrc(line: str) -> Optional[str]:
@@ -231,21 +217,28 @@ def scan_bank_ownership(
         else asm_paths
     )
     for asm_path in source_paths:
-        if _should_skip(asm_path):
-            continue
+        asm_path = asm_path.resolve()
+        try:
+            rel = str(asm_path.relative_to(root))
+        except ValueError as exc:
+            raise ManifestGenerationError(
+                f"Reachable ASM source is outside repo root: {asm_path}"
+            ) from exc
         try:
             text = asm_path.read_text(encoding="utf-8", errors="ignore")
-        except Exception:
-            continue
+        except OSError as exc:
+            raise ManifestGenerationError(
+                f"Unable to read reachable ASM source {asm_path}: {exc}"
+            ) from exc
 
-        rel = str(asm_path.relative_to(root))
         lines = text.splitlines()
 
         for i, line in enumerate(lines):
             # Check for org $XX8000+ (expanded bank entry points)
             m = ORG_BANK_RE.match(line)
             if m:
-                addr = int(m.group(1), 16)
+                source_addr = int(m.group(1), 16)
+                addr = _physical_org_address(source_addr)
                 bank = (addr >> 16) & 0xFF
                 # Only track expanded banks (>= $1E, avoiding vanilla $00-$1D)
                 if bank >= 0x1E:
@@ -264,12 +257,16 @@ def scan_bank_ownership(
                     for j in range(i + 1, min(i + 2000, len(lines))):
                         am = ASSERT_PC_RE.search(lines[j])
                         if am:
-                            end_addr = int(am.group(1), 16)
+                            end_addr = _physical_org_address(
+                                int(am.group(1), 16)
+                            )
                             break
                         # Stop at next org in a different bank
                         next_org = ORG_BANK_RE.match(lines[j])
                         if next_org:
-                            next_addr = int(next_org.group(1), 16)
+                            next_addr = _physical_org_address(
+                                int(next_org.group(1), 16)
+                            )
                             next_bank = (next_addr >> 16) & 0xFF
                             if next_bank != bank:
                                 break
@@ -287,7 +284,11 @@ def scan_bank_ownership(
             # Check for freedata bank $XX
             fm = FREEDATA_BANK_RE.match(line)
             if fm:
-                bank = int(fm.group(1), 16)
+                source_bank = int(fm.group(1), 16)
+                if source_bank in (0x7E, 0x7F):
+                    bank = source_bank
+                else:
+                    bank = source_bank & 0x7F
                 if bank >= 0x1E:
                     entry = {
                         "start": f"0x{bank:02X}8000",
@@ -317,12 +318,9 @@ def scan_bank_ownership(
         elif bank in EXPANSION_BANKS:
             ownership = "asm_expansion"
             ownership_note = "ROM expansion bank — does not exist in dev ROM, created by asar"
-        elif bank == 0x7E:
+        elif bank in (0x7E, 0x7F):
             ownership = "ram"
             ownership_note = "WRAM definitions (not ROM data)"
-        elif bank >= 0x80:
-            ownership = "mirror"
-            ownership_note = "HiROM mirror of vanilla bank"
         else:
             ownership = "asm_owned"
             ownership_note = "Fully owned by ASM hack"
@@ -444,14 +442,19 @@ def scan_room_tags(
         else asm_paths
     )
     for asm_path in source_paths:
-        if _should_skip(asm_path):
-            continue
+        asm_path = asm_path.resolve()
+        try:
+            rel = str(asm_path.relative_to(root))
+        except ValueError as exc:
+            raise ManifestGenerationError(
+                f"Reachable ASM source is outside repo root: {asm_path}"
+            ) from exc
         try:
             lines = asm_path.read_text(encoding="utf-8", errors="ignore").splitlines()
-        except Exception:
-            continue
-
-        rel = str(asm_path.relative_to(root))
+        except OSError as exc:
+            raise ManifestGenerationError(
+                f"Unable to read reachable ASM source {asm_path}: {exc}"
+            ) from exc
 
         # Track if/endif nesting for feature-gated tags
         in_gated_block = False
@@ -723,6 +726,38 @@ def _snes_to_pc(address: int) -> int:
     return ((address & 0x7F0000) >> 1) | (address & 0x7FFF)
 
 
+def _physical_org_address(address: int) -> int:
+    """Map an Asar org to its physical LoROM bank/address.
+
+    Asar sources may use FastROM mirrors such as $A0F000. Ownership must
+    describe the underlying $20F000 bytes rather than claiming a second,
+    whole mirror bank. WRAM orgs remain RAM metadata and are not ROM-mapped.
+    """
+    bank = (address >> 16) & 0xFF
+    if bank in (0x7E, 0x7F):
+        return address
+    return _canonical_lorom_address(address)
+
+
+def _strict_lorom_to_pc(address: int, description: str) -> int:
+    """Convert a ROM-sourced pointer only when it is valid mapped LoROM."""
+    if not 0 <= address <= 0xFFFFFF:
+        raise ManifestGenerationError(
+            f"{description} 0x{address:X} is outside 24-bit address space"
+        )
+    bank = (address >> 16) & 0xFF
+    offset = address & 0xFFFF
+    if bank in (0x7E, 0x7F):
+        raise ManifestGenerationError(
+            f"{description} 0x{address:06X} points to WRAM"
+        )
+    if offset < 0x8000:
+        raise ManifestGenerationError(
+            f"{description} 0x{address:06X} is not a high-half LoROM pointer"
+        )
+    return ((bank & 0x7F) << 15) | (offset & 0x7FFF)
+
+
 def _pc_to_snes(address: int) -> int:
     """Convert an unheadered PC offset to a canonical LoROM address."""
     if not 0 <= address < 0x400000:
@@ -792,7 +827,9 @@ def derive_editor_managed_regions(dev_rom_path: Path) -> list[dict]:
     header_table_snes = _read_u24(
         data, ROOM_HEADER_POINTER_PC, "room-header pointer-table operand"
     )
-    header_table_pc = _snes_to_pc(header_table_snes)
+    header_table_pc = _strict_lorom_to_pc(
+        header_table_snes, "Room-header pointer-table operand"
+    )
     _require_rom_span(
         data,
         header_table_pc,
@@ -812,7 +849,11 @@ def derive_editor_managed_regions(dev_rom_path: Path) -> list[dict]:
             pointer_pc,
             f"room-header pointer for room 0x{room_id:03X}",
         )
-        header_pc = _snes_to_pc((header_bank << 16) | header_offset)
+        header_address = (header_bank << 16) | header_offset
+        header_pc = _strict_lorom_to_pc(
+            header_address,
+            f"Room-header pointer for room 0x{room_id:03X}",
+        )
         _require_rom_span(
             data,
             header_pc,
@@ -925,8 +966,16 @@ def generate_manifest(root: Path, rom_path: Optional[Path] = None) -> dict:
     # Protected regions — these are hook addresses in VANILLA banks.
     # Asar overwrites these on build, so yaze edits here are lost.
     # Separate from owned_banks which are entirely ASM-owned.
-    vanilla_hooks = [h for h in hooks if h.address < 0x1E8000]
-    expanded_hooks = [h for h in hooks if h.address >= 0x1E8000]
+    vanilla_hooks = [
+        h
+        for h in hooks
+        if ((_physical_org_address(h.address) >> 16) & 0xFF) < 0x1E
+    ]
+    expanded_hooks = [
+        h
+        for h in hooks
+        if ((_physical_org_address(h.address) >> 16) & 0xFF) >= 0x1E
+    ]
     protected = compute_protected_regions(vanilla_hooks) if vanilla_hooks else []
     manifest["protected_regions"] = {
         "description": "Hook addresses within vanilla ROM banks ($00-$1D). Asar patches these on every build, so yaze edits at these addresses are silently overwritten. Yaze should either skip these during save or warn the user.",
@@ -946,7 +995,6 @@ def generate_manifest(root: Path, rom_path: Optional[Path] = None) -> dict:
             "shared": "Both yaze and ASM write — yaze edits base data, ASM patches hooks on top. Must rebuild after yaze save.",
             "asm_expansion": "ROM expansion bank — only exists in patched ROM, not in dev ROM",
             "ram": "WRAM variable definitions (not ROM data)",
-            "mirror": "HiROM mirror — ASM patches vanilla bank via mirror address",
         },
         "banks": banks,
     }

--- a/Scripts/Generate/generate_hack_manifest.py
+++ b/Scripts/Generate/generate_hack_manifest.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 from dataclasses import dataclass, field
@@ -190,6 +191,27 @@ def _iter_active_incsrcs(
             yield line_number, include_text
 
 
+def _is_case_exact_file(candidate: Path, root: Path) -> bool:
+    """Return whether a candidate exists with repository-exact path casing."""
+    normalized = Path(os.path.normpath(candidate))
+    try:
+        relative = normalized.relative_to(root)
+    except ValueError:
+        # Preserve the caller's existing outside-root diagnostic.
+        return candidate.is_file()
+
+    current = root
+    for part in relative.parts:
+        try:
+            entries = {entry.name: entry for entry in current.iterdir()}
+        except OSError:
+            return False
+        if part not in entries:
+            return False
+        current = entries[part]
+    return current.is_file()
+
+
 def collect_reachable_asm_sources(
     root: Path,
     entry_point: Path = MANIFEST_ENTRY_POINT,
@@ -244,7 +266,7 @@ def collect_reachable_asm_sources(
             )
             included = next(
                 (candidate.resolve() for candidate in candidates
-                 if candidate.is_file()),
+                 if _is_case_exact_file(candidate, resolved_root)),
                 None,
             )
             if included is None:

--- a/Scripts/Generate/generate_hack_manifest.py
+++ b/Scripts/Generate/generate_hack_manifest.py
@@ -9,7 +9,8 @@ Build pipeline context:
 
 Extends the hooks scanner to produce a comprehensive manifest that tells yaze:
   - Which ROM addresses are patched by asar (hooks/org directives)
-  - Which banks are fully owned by the ASM hack (expanded banks)
+  - Which reachable banks are fully owned by the ASM hack (expanded banks)
+  - Which live room-header/message ranges remain editor-managed
   - Expanded message layout and boundaries
   - Room tag mappings with semantics and feature flags
   - Feature flag state (compile-time toggles)
@@ -28,6 +29,10 @@ Address classification for yaze:
   - "hook_patched": Asar patches this address; yaze edits are overwritten on build
   - "asm_owned": Entire bank owned by hack; yaze should never write here
   - "shared": Both yaze and asar may reference (e.g., room headers ASM reads)
+
+ASM ownership follows the literal incsrc graph rooted at Oracle_main.asm.
+Ignored assets and archived experiments that are not assembled cannot claim
+ROM ownership.
 """
 from __future__ import annotations
 
@@ -37,7 +42,7 @@ import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
+from typing import Iterable, Optional
 
 # Import the existing hooks scanner infrastructure
 from generate_hooks_json import (
@@ -88,6 +93,13 @@ ASSERT_PC_RE = re.compile(r"assert\s+pc\(\)\s*<=\s*\$([0-9A-Fa-f]{6})")
 # Comment with purpose annotation
 PURPOSE_COMMENT_RE = re.compile(r";\s*(.+)$")
 
+# Literal Asar source include. Paths may be quoted or bare; comments are
+# stripped before matching so archived `; incsrc ...` lines stay unreachable.
+INCSRC_RE = re.compile(
+    r"^\s*incsrc\s+(?:\"([^\"]+)\"|'([^']+)'|([^\s;]+))",
+    re.IGNORECASE,
+)
+
 SKIP_DIRS = {
     ".git", ".context", ".claude", ".cursor",
     "Roms", "Docs", "docs",
@@ -95,12 +107,101 @@ SKIP_DIRS = {
     "ZScreamNew",
 }
 
+MANIFEST_ENTRY_POINT = Path("Oracle_main.asm")
+DUNGEON_ROOM_COUNT = 296
+ROOM_HEADER_POINTER_PC = 0xB5DD
+ROOM_HEADER_BANK_PC = 0xB5E7
+ROOM_HEADER_SIZE = 14
+DUNGEON_MESSAGE_IDS_PC = 0x3F61D
+
+
+class ManifestGenerationError(RuntimeError):
+    """Raised when source or ROM evidence cannot safely define ownership."""
+
 
 def _should_skip(path: Path) -> bool:
     for part in path.parts:
         if part in SKIP_DIRS:
             return True
     return False
+
+
+def _parse_incsrc(line: str) -> Optional[str]:
+    """Return a literal `incsrc` path from uncommented source text."""
+    source = line.split(";", 1)[0]
+    match = INCSRC_RE.match(source)
+    if not match:
+        return None
+    return next(value for value in match.groups() if value is not None)
+
+
+def collect_reachable_asm_sources(
+    root: Path,
+    entry_point: Path = MANIFEST_ENTRY_POINT,
+) -> list[Path]:
+    """Collect the transitive literal `incsrc` graph for the build entry.
+
+    Asar sources in this repository use both paths relative to the including
+    file and repo-root-relative paths. Try those forms in that order and fail
+    closed if a reachable include cannot be resolved.
+    """
+    resolved_root = root.resolve()
+    entry = entry_point if entry_point.is_absolute() else resolved_root / entry_point
+    entry = entry.resolve()
+    if not entry.is_file():
+        raise ManifestGenerationError(f"ASM entry point not found: {entry}")
+    if not entry.is_relative_to(resolved_root):
+        raise ManifestGenerationError(
+            f"ASM entry point is outside repo root: {entry}"
+        )
+
+    pending = [entry]
+    reachable: set[Path] = set()
+    while pending:
+        asm_path = pending.pop()
+        if asm_path in reachable:
+            continue
+        reachable.add(asm_path)
+
+        try:
+            lines = asm_path.read_text(
+                encoding="utf-8", errors="ignore"
+            ).splitlines()
+        except OSError as exc:
+            raise ManifestGenerationError(
+                f"Unable to read reachable ASM source {asm_path}: {exc}"
+            ) from exc
+
+        for line_number, line in enumerate(lines, start=1):
+            include_text = _parse_incsrc(line)
+            if include_text is None:
+                continue
+
+            include_path = Path(include_text)
+            candidates = (
+                asm_path.parent / include_path,
+                resolved_root / include_path,
+            )
+            included = next(
+                (candidate.resolve() for candidate in candidates
+                 if candidate.is_file()),
+                None,
+            )
+            if included is None:
+                rel = asm_path.relative_to(resolved_root)
+                raise ManifestGenerationError(
+                    f"{rel}:{line_number}: unresolved incsrc "
+                    f"{include_text!r}"
+                )
+            if not included.is_relative_to(resolved_root):
+                rel = asm_path.relative_to(resolved_root)
+                raise ManifestGenerationError(
+                    f"{rel}:{line_number}: incsrc escapes repo root: "
+                    f"{include_text!r}"
+                )
+            pending.append(included)
+
+    return sorted(reachable)
 
 
 # ---------------------------------------------------------------------------
@@ -116,11 +217,20 @@ class BankRegion:
     purpose: str = ""
 
 
-def scan_bank_ownership(root: Path) -> list[dict]:
-    """Detect which banks are owned by the hack via org directives."""
+def scan_bank_ownership(
+    root: Path,
+    asm_paths: Optional[Iterable[Path]] = None,
+) -> list[dict]:
+    """Detect owned banks from sources reachable by the build entry point."""
+    root = root.resolve()
     bank_sources: dict[int, list[dict]] = {}
 
-    for asm_path in root.rglob("*.asm"):
+    source_paths = (
+        collect_reachable_asm_sources(root)
+        if asm_paths is None
+        else asm_paths
+    )
+    for asm_path in source_paths:
         if _should_skip(asm_path):
             continue
         try:
@@ -319,11 +429,21 @@ def scan_message_layout(root: Path) -> dict:
 # Room tag extraction
 # ---------------------------------------------------------------------------
 
-def scan_room_tags(root: Path, defines: dict[str, int]) -> list[dict]:
+def scan_room_tags(
+    root: Path,
+    defines: dict[str, int],
+    asm_paths: Optional[Iterable[Path]] = None,
+) -> list[dict]:
     """Extract room tag mappings from org $01CCxx directives."""
+    root = root.resolve()
     tags: dict[int, dict] = {}
 
-    for asm_path in root.rglob("*.asm"):
+    source_paths = (
+        collect_reachable_asm_sources(root)
+        if asm_paths is None
+        else asm_paths
+    )
+    for asm_path in source_paths:
         if _should_skip(asm_path):
             continue
         try:
@@ -530,9 +650,6 @@ def compute_protected_regions(hooks: list[HookEntry]) -> list[dict]:
     if not hooks:
         return []
 
-    # Sort hooks by address
-    sorted_hooks = sorted(hooks, key=lambda h: h.address)
-
     # Estimate size of each hook (conservative: 4 bytes for JML/JSL, 1-8 for data/patch)
     SIZE_ESTIMATE = {
         "jsl": 4,
@@ -543,41 +660,192 @@ def compute_protected_regions(hooks: list[HookEntry]) -> list[dict]:
         "patch": 4,   # conservative
     }
 
+    # Group in PC space so legacy low-half mirrors and bank crossings produce
+    # canonical, increasing LoROM half-open ranges in manifest v3.
+    sorted_hooks = sorted(hooks, key=lambda hook: _snes_to_pc(hook.address))
     regions = []
-    current_start = sorted_hooks[0].address
+    current_start = _snes_to_pc(sorted_hooks[0].address)
     current_end = current_start + SIZE_ESTIMATE.get(sorted_hooks[0].kind, 4)
     current_hooks = [sorted_hooks[0]]
 
     for hook in sorted_hooks[1:]:
-        hook_end = hook.address + SIZE_ESTIMATE.get(hook.kind, 4)
+        hook_start = _snes_to_pc(hook.address)
+        hook_end = hook_start + SIZE_ESTIMATE.get(hook.kind, 4)
 
         # Merge if within 16 bytes of the previous region (likely related)
-        if hook.address <= current_end + 16:
+        if hook_start <= current_end + 16:
             current_end = max(current_end, hook_end)
             current_hooks.append(hook)
         else:
             # Emit previous region
             regions.append({
-                "start": f"0x{current_start:06X}",
-                "end": f"0x{current_end:06X}",
+                "start": f"0x{_pc_to_snes(current_start):06X}",
+                "end": f"0x{_pc_to_snes(current_end):06X}",
                 "size": current_end - current_start,
                 "hook_count": len(current_hooks),
                 "module": current_hooks[0].module,
             })
-            current_start = hook.address
+            current_start = hook_start
             current_end = hook_end
             current_hooks = [hook]
 
     # Emit last region
     regions.append({
-        "start": f"0x{current_start:06X}",
-        "end": f"0x{current_end:06X}",
+        "start": f"0x{_pc_to_snes(current_start):06X}",
+        "end": f"0x{_pc_to_snes(current_end):06X}",
         "size": current_end - current_start,
         "hook_count": len(current_hooks),
         "module": current_hooks[0].module,
     })
 
     return regions
+
+
+# ---------------------------------------------------------------------------
+# Exact editor-managed ROM ranges
+# ---------------------------------------------------------------------------
+
+def _canonical_lorom_address(address: int) -> int:
+    """Return the canonical mapped LoROM mirror for a 24-bit address."""
+    if not 0 <= address <= 0xFFFFFF:
+        raise ManifestGenerationError(
+            f"SNES address 0x{address:X} is outside 24-bit address space"
+        )
+    address &= 0x7FFFFF
+    if (address & 0xFFFF) < 0x8000:
+        address |= 0x8000
+    return address
+
+
+def _snes_to_pc(address: int) -> int:
+    """Convert a canonical LoROM address to an unheadered PC offset."""
+    address = _canonical_lorom_address(address)
+    return ((address & 0x7F0000) >> 1) | (address & 0x7FFF)
+
+
+def _pc_to_snes(address: int) -> int:
+    """Convert an unheadered PC offset to a canonical LoROM address."""
+    if not 0 <= address < 0x400000:
+        raise ManifestGenerationError(
+            f"PC address 0x{address:X} is outside canonical LoROM"
+        )
+    snes = (
+        ((address << 1) & 0x7F0000)
+        | (address & 0x7FFF)
+        | 0x8000
+    )
+    if _snes_to_pc(snes) != address:
+        raise ManifestGenerationError(
+            f"PC address 0x{address:X} does not round-trip through LoROM"
+        )
+    return snes
+
+
+def _require_rom_span(
+    data: bytes,
+    address: int,
+    size: int,
+    description: str,
+) -> None:
+    if address < 0 or size < 0 or address + size > len(data):
+        raise ManifestGenerationError(
+            f"{description} PC span [0x{address:X}, "
+            f"0x{address + size:X}) exceeds dev ROM size 0x{len(data):X}"
+        )
+
+
+def _read_u16(data: bytes, address: int, description: str) -> int:
+    _require_rom_span(data, address, 2, description)
+    return data[address] | (data[address + 1] << 8)
+
+
+def _read_u24(data: bytes, address: int, description: str) -> int:
+    _require_rom_span(data, address, 3, description)
+    return (
+        data[address]
+        | (data[address + 1] << 8)
+        | (data[address + 2] << 16)
+    )
+
+
+def _editor_range(start_pc: int, end_pc: int) -> dict[str, str]:
+    if start_pc >= end_pc:
+        raise ManifestGenerationError(
+            f"Invalid editor-managed PC range "
+            f"[0x{start_pc:X}, 0x{end_pc:X})"
+        )
+    return {
+        "start": f"0x{_pc_to_snes(start_pc):06X}",
+        "end": f"0x{_pc_to_snes(end_pc):06X}",
+    }
+
+
+def derive_editor_managed_regions(dev_rom_path: Path) -> list[dict]:
+    """Derive exact room-header and message-ID ranges from the dev ROM."""
+    try:
+        data = dev_rom_path.read_bytes()
+    except OSError as exc:
+        raise ManifestGenerationError(
+            f"Unable to read dev ROM {dev_rom_path}: {exc}"
+        ) from exc
+
+    header_table_snes = _read_u24(
+        data, ROOM_HEADER_POINTER_PC, "room-header pointer-table operand"
+    )
+    header_table_pc = _snes_to_pc(header_table_snes)
+    _require_rom_span(
+        data,
+        header_table_pc,
+        DUNGEON_ROOM_COUNT * 2,
+        "room-header pointer table",
+    )
+    _require_rom_span(
+        data, ROOM_HEADER_BANK_PC, 1, "room-header pointer bank"
+    )
+    header_bank = data[ROOM_HEADER_BANK_PC]
+
+    header_ranges: list[tuple[int, int]] = []
+    for room_id in range(DUNGEON_ROOM_COUNT):
+        pointer_pc = header_table_pc + room_id * 2
+        header_offset = _read_u16(
+            data,
+            pointer_pc,
+            f"room-header pointer for room 0x{room_id:03X}",
+        )
+        header_pc = _snes_to_pc((header_bank << 16) | header_offset)
+        _require_rom_span(
+            data,
+            header_pc,
+            ROOM_HEADER_SIZE,
+            f"room header 0x{room_id:03X}",
+        )
+        header_ranges.append((header_pc, header_pc + ROOM_HEADER_SIZE))
+
+    sorted_headers = sorted(header_ranges)
+    if len(set(sorted_headers)) != DUNGEON_ROOM_COUNT:
+        raise ManifestGenerationError(
+            "Room-header pointers are not unique across all 296 rooms"
+        )
+    for previous, current in zip(sorted_headers, sorted_headers[1:]):
+        if current[0] != previous[1]:
+            raise ManifestGenerationError(
+                "Room headers are not one contiguous 296-record range: "
+                f"[0x{previous[0]:X}, 0x{previous[1]:X}) is followed by "
+                f"[0x{current[0]:X}, 0x{current[1]:X})"
+            )
+
+    messages_end_pc = DUNGEON_MESSAGE_IDS_PC + DUNGEON_ROOM_COUNT * 2
+    _require_rom_span(
+        data,
+        DUNGEON_MESSAGE_IDS_PC,
+        DUNGEON_ROOM_COUNT * 2,
+        "dungeon room message IDs",
+    )
+
+    return [
+        _editor_range(sorted_headers[0][0], sorted_headers[-1][1]),
+        _editor_range(DUNGEON_MESSAGE_IDS_PC, messages_end_pc),
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -588,15 +856,19 @@ def generate_manifest(root: Path, rom_path: Optional[Path] = None) -> dict:
     """Generate the complete hack manifest."""
     import hashlib
 
+    root = root.resolve()
+    asm_sources = collect_reachable_asm_sources(root)
+
     # Load defines for conditional compilation evaluation
     defines = _load_global_defines(root)
 
-    # Scan hooks (reuse existing infrastructure)
-    hooks = scan_hooks(root)
+    # Scan only the source graph assembled from Oracle_main.asm. Local ignored
+    # assets and archived experiments must not claim ROM ownership.
+    hooks = scan_hooks(root, asm_sources)
 
     # Build manifest sections
     manifest: dict = {
-        "manifest_version": 2,
+        "manifest_version": 3,
         "hack_name": "Oracle of Secrets",
         "hack_version": "dev",
         "generator": "generate_hack_manifest.py",
@@ -608,8 +880,8 @@ def generate_manifest(root: Path, rom_path: Optional[Path] = None) -> dict:
         "dev_rom": "Roms/oos168.sfc",
         "patched_rom": "Roms/oos168x.sfc",
         "assembler": "asar",
-        "entry_point": "Meadow_main.asm",
-        "build_script": "Scripts/build_rom.sh",
+        "entry_point": str(MANIFEST_ENTRY_POINT),
+        "build_script": "Scripts/Build/build_rom.sh",
         "flow": [
             "1. Yaze edits dev ROM (room data, sprites, palettes, messages)",
             "2. asar reads dev ROM + ASM sources",
@@ -640,6 +912,16 @@ def generate_manifest(root: Path, rom_path: Optional[Path] = None) -> dict:
             pass
     manifest["rom"] = rom_meta
 
+    if dev_rom_path.exists():
+        manifest["editor_managed_regions"] = {
+            "description": (
+                "Exact room-header and per-room message-ID ranges derived "
+                "from the editable dev ROM. Protected hooks still take "
+                "precedence."
+            ),
+            "regions": derive_editor_managed_regions(dev_rom_path),
+        }
+
     # Protected regions — these are hook addresses in VANILLA banks.
     # Asar overwrites these on build, so yaze edits here are lost.
     # Separate from owned_banks which are entirely ASM-owned.
@@ -656,7 +938,7 @@ def generate_manifest(root: Path, rom_path: Optional[Path] = None) -> dict:
     }
 
     # Bank ownership — expanded banks with ownership classification
-    banks = scan_bank_ownership(root)
+    banks = scan_bank_ownership(root, asm_sources)
     manifest["owned_banks"] = {
         "description": "Expanded ROM banks with ownership classification. 'asm_owned' banks are fully owned by ASM. 'shared' banks (e.g., $28 ZSCustomOverworld) contain data that yaze writes AND ASM patches on top — yaze can edit these but must rebuild after. 'asm_expansion' banks only exist in the patched ROM.",
         "ownership_types": {
@@ -687,7 +969,7 @@ def generate_manifest(root: Path, rom_path: Optional[Path] = None) -> dict:
     # Room tags — the dispatch table at $01CC00-$01CC5A is in vanilla bank $01.
     # Asar patches specific 4-byte slots (JML instructions). Yaze's room editor
     # assigns tag IDs to rooms; this manifest tells yaze what each tag ID means.
-    room_tags = scan_room_tags(root, defines)
+    room_tags = scan_room_tags(root, defines, asm_sources)
     manifest["room_tags"] = {
         "description": "Custom room tag dispatch table entries in bank $01. Asar patches 4-byte JML slots at these addresses. Yaze assigns tag IDs to rooms via room headers — this manifest provides labels and semantics so the editor can show meaningful names instead of raw tag numbers.",
         "dispatch_table_start": "0x01CC00",
@@ -773,7 +1055,11 @@ def main() -> int:
     if not rom_path.exists():
         rom_path = None
 
-    manifest = generate_manifest(root, rom_path)
+    try:
+        manifest = generate_manifest(root, rom_path)
+    except ManifestGenerationError as exc:
+        print(f"error: cannot generate hack manifest: {exc}", file=sys.stderr)
+        return 1
 
     indent = None if args.compact else 2
     output.write_text(json.dumps(manifest, indent=indent) + "\n")

--- a/Scripts/Generate/generate_hack_manifest.py
+++ b/Scripts/Generate/generate_hack_manifest.py
@@ -46,9 +46,14 @@ from typing import Iterable, Optional
 
 # Import the existing hooks scanner infrastructure
 from generate_hooks_json import (
+    ELSE_DIRECTIVE_RE,
+    ENDIF_DIRECTIVE_RE,
+    IF_DIRECTIVE_RE,
+    _eval_condition,
     filter_active_asm_sources,
     scan_hooks,
     _load_global_defines,
+    _parse_define_assignment,
     HookEntry,
 )
 
@@ -122,15 +127,80 @@ def _parse_incsrc(line: str) -> Optional[str]:
     return next(value for value in match.groups() if value is not None)
 
 
+def _iter_active_incsrcs(
+    lines: list[str],
+    global_defines: dict[str, int],
+) -> Iterable[tuple[int, str]]:
+    """Yield literal includes whose enclosing Asar condition is active."""
+    defines = dict(global_defines)
+    active = True
+    stack: list[dict[str, object]] = []
+
+    for line_number, line in enumerate(lines, start=1):
+        directive = line.split(";", 1)[0].strip()
+        match = IF_DIRECTIVE_RE.match(directive)
+        if match:
+            kind = match.group(1).lower()
+            condition = _eval_condition(match.group(2).strip(), defines)
+            condition_active = (
+                bool(condition) if condition is not None else True
+            )
+            if kind == "if":
+                parent_active = active
+                branch_taken = parent_active and condition_active
+                active = branch_taken
+                stack.append({
+                    "parent_active": parent_active,
+                    "branch_taken": branch_taken,
+                })
+            elif stack:
+                frame = stack[-1]
+                parent_active = bool(frame["parent_active"])
+                branch_taken = bool(frame["branch_taken"])
+                active = (
+                    parent_active
+                    and not branch_taken
+                    and condition_active
+                )
+                frame["branch_taken"] = branch_taken or active
+            continue
+        if ELSE_DIRECTIVE_RE.match(directive):
+            if stack:
+                frame = stack[-1]
+                parent_active = bool(frame["parent_active"])
+                branch_taken = bool(frame["branch_taken"])
+                active = parent_active and not branch_taken
+                frame["branch_taken"] = True
+            continue
+        if ENDIF_DIRECTIVE_RE.match(directive):
+            if stack:
+                frame = stack.pop()
+                active = bool(frame["parent_active"])
+            continue
+        if not active:
+            continue
+
+        parsed_define = _parse_define_assignment(line)
+        if parsed_define is not None:
+            name, value = parsed_define
+            defines[name] = value
+
+        include_text = _parse_incsrc(line)
+        if include_text is not None:
+            yield line_number, include_text
+
+
 def collect_reachable_asm_sources(
     root: Path,
     entry_point: Path = MANIFEST_ENTRY_POINT,
+    defines: Optional[dict[str, int]] = None,
 ) -> list[Path]:
     """Collect the transitive literal `incsrc` graph for the build entry.
 
     Asar sources in this repository use both paths relative to the including
-    file and repo-root-relative paths. Try those forms in that order and fail
-    closed if a reachable include cannot be resolved.
+    file and repo-root-relative paths. Follow only active conditional edges,
+    gate disabled module roots before traversal, and fail closed if an active
+    reachable include cannot be resolved.
     """
     resolved_root = root.resolve()
     entry = entry_point if entry_point.is_absolute() else resolved_root / entry_point
@@ -142,6 +212,11 @@ def collect_reachable_asm_sources(
             f"ASM entry point is outside repo root: {entry}"
         )
 
+    active_defines = (
+        _load_global_defines(resolved_root)
+        if defines is None
+        else dict(defines)
+    )
     pending = [entry]
     reachable: set[Path] = set()
     while pending:
@@ -159,11 +234,9 @@ def collect_reachable_asm_sources(
                 f"Unable to read reachable ASM source {asm_path}: {exc}"
             ) from exc
 
-        for line_number, line in enumerate(lines, start=1):
-            include_text = _parse_incsrc(line)
-            if include_text is None:
-                continue
-
+        for line_number, include_text in _iter_active_incsrcs(
+            lines, active_defines
+        ):
             include_path = Path(include_text)
             candidates = (
                 asm_path.parent / include_path,
@@ -186,6 +259,10 @@ def collect_reachable_asm_sources(
                     f"{rel}:{line_number}: incsrc escapes repo root: "
                     f"{include_text!r}"
                 )
+            if not filter_active_asm_sources(
+                resolved_root, [included], active_defines
+            ):
+                continue
             pending.append(included)
 
     return sorted(reachable)

--- a/Scripts/Generate/generate_hack_manifest.py
+++ b/Scripts/Generate/generate_hack_manifest.py
@@ -46,6 +46,7 @@ from typing import Iterable, Optional
 
 # Import the existing hooks scanner infrastructure
 from generate_hooks_json import (
+    filter_active_asm_sources,
     scan_hooks,
     _load_global_defines,
     HookEntry,
@@ -211,11 +212,12 @@ def scan_bank_ownership(
     root = root.resolve()
     bank_sources: dict[int, list[dict]] = {}
 
-    source_paths = (
+    candidate_paths = (
         collect_reachable_asm_sources(root)
         if asm_paths is None
         else asm_paths
     )
+    source_paths = filter_active_asm_sources(root, candidate_paths)
     for asm_path in source_paths:
         asm_path = asm_path.resolve()
         try:
@@ -436,10 +438,13 @@ def scan_room_tags(
     root = root.resolve()
     tags: dict[int, dict] = {}
 
-    source_paths = (
+    candidate_paths = (
         collect_reachable_asm_sources(root)
         if asm_paths is None
         else asm_paths
+    )
+    source_paths = filter_active_asm_sources(
+        root, candidate_paths, defines
     )
     for asm_path in source_paths:
         asm_path = asm_path.resolve()
@@ -898,10 +903,13 @@ def generate_manifest(root: Path, rom_path: Optional[Path] = None) -> dict:
     import hashlib
 
     root = root.resolve()
-    asm_sources = collect_reachable_asm_sources(root)
+    reachable_sources = collect_reachable_asm_sources(root)
 
     # Load defines for conditional compilation evaluation
     defines = _load_global_defines(root)
+    asm_sources = filter_active_asm_sources(
+        root, reachable_sources, defines
+    )
 
     # Scan only the source graph assembled from Oracle_main.asm. Local ignored
     # assets and archived experiments must not claim ROM ownership.

--- a/Scripts/Generate/generate_hooks_json.py
+++ b/Scripts/Generate/generate_hooks_json.py
@@ -449,6 +449,7 @@ def scan_hooks(
 ) -> list[HookEntry]:
     root = root.resolve()
     hooks_by_addr: dict[int, HookEntry] = {}
+    explicit_sources = asm_paths is not None
 
     global_defines = _load_global_defines(root)
     disabled_dirs: set[str] = set()
@@ -468,17 +469,27 @@ def scan_hooks(
         disabled_dirs.add("Menu")
 
     source_paths = root.rglob('*.asm') if asm_paths is None else asm_paths
-    for asm_path in source_paths:
-        if _should_skip(asm_path):
+    for source_path in source_paths:
+        asm_path = source_path.resolve()
+        if not explicit_sources and _should_skip(asm_path):
             continue
-        rel = asm_path.relative_to(root)
+        try:
+            rel = asm_path.relative_to(root)
+        except ValueError:
+            if explicit_sources:
+                raise ValueError(
+                    f"Explicit ASM source is outside repo root: {asm_path}"
+                )
+            continue
         if rel.parts and rel.parts[0] in disabled_dirs:
             continue
         if global_defines.get("DISABLE_PATCHES") == 1 and rel.as_posix() == "Core/patches.asm":
             continue
         try:
             lines = asm_path.read_text(encoding='utf-8', errors='ignore').splitlines()
-        except Exception:
+        except OSError:
+            if explicit_sources:
+                raise
             continue
 
         defines = dict(global_defines)

--- a/Scripts/Generate/generate_hooks_json.py
+++ b/Scripts/Generate/generate_hooks_json.py
@@ -54,6 +54,16 @@ SKIP_DIRS = {
     'ZScreamNew',
 }
 
+MODULE_DISABLE_FLAGS = {
+    "Music": "DISABLE_MUSIC",
+    "Overworld": "DISABLE_OVERWORLD",
+    "Dungeons": "DISABLE_DUNGEON",
+    "Sprites": "DISABLE_SPRITES",
+    "Masks": "DISABLE_MASKS",
+    "Items": "DISABLE_ITEMS",
+    "Menu": "DISABLE_MENU",
+}
+
 EXPECTED_MX = {
     0x008000: (8, 8),     # Reset
     0x0080C9: (8, 8),     # NMI
@@ -443,6 +453,40 @@ def _should_skip(path: Path) -> bool:
     return False
 
 
+def filter_active_asm_sources(
+    root: Path,
+    asm_paths: Iterable[Path],
+    defines: Optional[dict[str, int]] = None,
+) -> list[Path]:
+    """Remove top-level modules disabled by the current build flags."""
+    root = root.resolve()
+    active_defines = _load_global_defines(root) if defines is None else defines
+    disabled_roots = {
+        source_root
+        for source_root, flag in MODULE_DISABLE_FLAGS.items()
+        if active_defines.get(flag) == 1
+    }
+
+    active_sources: list[Path] = []
+    for source_path in asm_paths:
+        asm_path = source_path.resolve()
+        try:
+            rel = asm_path.relative_to(root)
+        except ValueError as exc:
+            raise ValueError(
+                f"ASM source is outside repo root: {asm_path}"
+            ) from exc
+        if rel.parts and rel.parts[0] in disabled_roots:
+            continue
+        if (
+            active_defines.get("DISABLE_PATCHES") == 1
+            and rel.as_posix() == "Core/patches.asm"
+        ):
+            continue
+        active_sources.append(asm_path)
+    return active_sources
+
+
 def scan_hooks(
     root: Path,
     asm_paths: Optional[Iterable[Path]] = None,
@@ -452,24 +496,11 @@ def scan_hooks(
     explicit_sources = asm_paths is not None
 
     global_defines = _load_global_defines(root)
-    disabled_dirs: set[str] = set()
-    if global_defines.get("DISABLE_MUSIC") == 1:
-        disabled_dirs.add("Music")
-    if global_defines.get("DISABLE_OVERWORLD") == 1:
-        disabled_dirs.add("Overworld")
-    if global_defines.get("DISABLE_DUNGEON") == 1:
-        disabled_dirs.add("Dungeons")
-    if global_defines.get("DISABLE_SPRITES") == 1:
-        disabled_dirs.add("Sprites")
-    if global_defines.get("DISABLE_MASKS") == 1:
-        disabled_dirs.add("Masks")
-    if global_defines.get("DISABLE_ITEMS") == 1:
-        disabled_dirs.add("Items")
-    if global_defines.get("DISABLE_MENU") == 1:
-        disabled_dirs.add("Menu")
-
     source_paths = root.rglob('*.asm') if asm_paths is None else asm_paths
-    for source_path in source_paths:
+    active_sources = filter_active_asm_sources(
+        root, source_paths, global_defines
+    )
+    for source_path in active_sources:
         asm_path = source_path.resolve()
         if not explicit_sources and _should_skip(asm_path):
             continue
@@ -480,10 +511,6 @@ def scan_hooks(
                 raise ValueError(
                     f"Explicit ASM source is outside repo root: {asm_path}"
                 )
-            continue
-        if rel.parts and rel.parts[0] in disabled_dirs:
-            continue
-        if global_defines.get("DISABLE_PATCHES") == 1 and rel.as_posix() == "Core/patches.asm":
             continue
         try:
             lines = asm_path.read_text(encoding='utf-8', errors='ignore').splitlines()

--- a/Scripts/Generate/generate_hooks_json.py
+++ b/Scripts/Generate/generate_hooks_json.py
@@ -14,7 +14,7 @@ import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Iterable, Optional
 
 ORG_RE = re.compile(r'^\s*org\s+\$([0-9A-Fa-f]{6})\b')
 LABEL_RE = re.compile(r'^\s*[A-Za-z0-9_\.\+\-]+:\s*$')
@@ -443,7 +443,11 @@ def _should_skip(path: Path) -> bool:
     return False
 
 
-def scan_hooks(root: Path) -> list[HookEntry]:
+def scan_hooks(
+    root: Path,
+    asm_paths: Optional[Iterable[Path]] = None,
+) -> list[HookEntry]:
+    root = root.resolve()
     hooks_by_addr: dict[int, HookEntry] = {}
 
     global_defines = _load_global_defines(root)
@@ -463,7 +467,8 @@ def scan_hooks(root: Path) -> list[HookEntry]:
     if global_defines.get("DISABLE_MENU") == 1:
         disabled_dirs.add("Menu")
 
-    for asm_path in root.rglob('*.asm'):
+    source_paths = root.rglob('*.asm') if asm_paths is None else asm_paths
+    for asm_path in source_paths:
         if _should_skip(asm_path):
             continue
         rel = asm_path.relative_to(root)

--- a/Scripts/Generate/tests/test_generate_hack_manifest.py
+++ b/Scripts/Generate/tests/test_generate_hack_manifest.py
@@ -221,6 +221,42 @@ class ReachableSourceTest(unittest.TestCase):
             {"0x20AF20", "0x20F000"},
         )
 
+    def test_disabled_overworld_incsrc_cannot_leak_manifest_state(
+        self,
+    ) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm",
+            'incsrc "Config/module_flags.asm"\n'
+            'incsrc "Core/active.asm"\n'
+            'incsrc "Overworld/disabled.asm"\n',
+        )
+        self.fixture.write_text(
+            "Config/module_flags.asm",
+            "!DISABLE_OVERWORLD = 1\n",
+        )
+        self.fixture.write_text(
+            "Core/active.asm",
+            "org $2E8000\n"
+            "db $00\n",
+        )
+        self.fixture.write_text(
+            "Overworld/disabled.asm",
+            "org $008200\n"
+            "JSL DisabledOverworldHook\n"
+            "org $01CC18 : JML DisabledTag ; @hook name=DisabledTag\n"
+            "org $408000\n"
+            "db $00\n",
+        )
+
+        manifest = generate_manifest(self.fixture.root)
+        owned_banks = {
+            entry["bank"] for entry in manifest["owned_banks"]["banks"]
+        }
+
+        self.assertEqual(manifest["summary"]["total_hooks"], 1)
+        self.assertEqual(owned_banks, {"0x2E"})
+        self.assertEqual(manifest["room_tags"]["tags"], [])
+
 
 class RepositorySourceRegressionTest(unittest.TestCase):
     def test_real_fastrom_orgs_use_physical_manifest_ranges(self) -> None:

--- a/Scripts/Generate/tests/test_generate_hack_manifest.py
+++ b/Scripts/Generate/tests/test_generate_hack_manifest.py
@@ -137,6 +137,18 @@ class ReachableSourceTest(unittest.TestCase):
         ):
             collect_reachable_asm_sources(self.fixture.root)
 
+    def test_case_mismatched_include_fails_closed(self) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm", 'incsrc "Core/Active.asm"\n'
+        )
+        self.fixture.write_text("Core/active.asm", "org $2E8000\n")
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            r"Oracle_main\.asm:1: unresolved incsrc 'Core/Active\.asm'",
+        ):
+            collect_reachable_asm_sources(self.fixture.root)
+
     def test_disabled_sprite_edge_blocks_cross_root_descendants(
         self,
     ) -> None:

--- a/Scripts/Generate/tests/test_generate_hack_manifest.py
+++ b/Scripts/Generate/tests/test_generate_hack_manifest.py
@@ -137,6 +137,90 @@ class ReachableSourceTest(unittest.TestCase):
         ):
             collect_reachable_asm_sources(self.fixture.root)
 
+    def test_disabled_sprite_edge_blocks_cross_root_descendants(
+        self,
+    ) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm",
+            'incsrc "Config/module_flags.asm"\n'
+            "if !DISABLE_SPRITES == 0\n"
+            '  incsrc "Sprites/disabled.asm"\n'
+            "endif\n"
+            'incsrc "Core/shared.asm"\n',
+        )
+        self.fixture.write_text(
+            "Config/module_flags.asm",
+            "!DISABLE_SPRITES = 1\n",
+        )
+        self.fixture.write_text(
+            "Sprites/disabled.asm",
+            'incsrc "../Core/sprite_only.asm"\n'
+            'incsrc "../Core/shared.asm"\n',
+        )
+        self.fixture.write_text(
+            "Core/sprite_only.asm",
+            "org $2F8000\n"
+            "db $00\n",
+        )
+        self.fixture.write_text(
+            "Core/shared.asm",
+            "org $2E8000\n"
+            "db $00\n",
+        )
+
+        sources = {
+            path.relative_to(self.fixture.root.resolve()).as_posix()
+            for path in collect_reachable_asm_sources(self.fixture.root)
+        }
+        manifest = generate_manifest(self.fixture.root)
+
+        self.assertEqual(
+            sources,
+            {
+                "Oracle_main.asm",
+                "Config/module_flags.asm",
+                "Core/shared.asm",
+            },
+        )
+        self.assertEqual(
+            {
+                entry["bank"]
+                for entry in manifest["owned_banks"]["banks"]
+            },
+            {"0x2E"},
+        )
+
+    def test_missing_include_in_inactive_module_condition_is_ignored(
+        self,
+    ) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm",
+            'incsrc "Config/module_flags.asm"\n'
+            "if !DISABLE_SPRITES == 0\n"
+            '  incsrc "Sprites/missing.asm"\n'
+            "endif\n"
+            'incsrc "Core/active.asm"\n',
+        )
+        self.fixture.write_text(
+            "Config/module_flags.asm",
+            "!DISABLE_SPRITES = 1\n",
+        )
+        self.fixture.write_text("Core/active.asm", "org $2E8000\n")
+
+        sources = {
+            path.relative_to(self.fixture.root.resolve()).as_posix()
+            for path in collect_reachable_asm_sources(self.fixture.root)
+        }
+
+        self.assertEqual(
+            sources,
+            {
+                "Oracle_main.asm",
+                "Config/module_flags.asm",
+                "Core/active.asm",
+            },
+        )
+
     def test_manifest_excludes_unreachable_bank_claims_and_hooks(self) -> None:
         self.fixture.write_text(
             "Oracle_main.asm", 'incsrc "Core/active.asm"\n'

--- a/Scripts/Generate/tests/test_generate_hack_manifest.py
+++ b/Scripts/Generate/tests/test_generate_hack_manifest.py
@@ -6,6 +6,7 @@ import unittest
 from pathlib import Path
 
 GENERATE_DIR = Path(__file__).resolve().parents[1]
+REPO_ROOT = GENERATE_DIR.parents[1]
 sys.path.insert(0, str(GENERATE_DIR))
 
 from generate_hack_manifest import (  # noqa: E402
@@ -66,6 +67,17 @@ class ManifestFixture:
         rom_path.parent.mkdir(parents=True, exist_ok=True)
         rom_path.write_bytes(data)
         return rom_path
+
+    @staticmethod
+    def write_rom_value(
+        rom_path: Path,
+        offset: int,
+        value: int,
+        size: int,
+    ) -> None:
+        data = bytearray(rom_path.read_bytes())
+        data[offset:offset + size] = value.to_bytes(size, "little")
+        rom_path.write_bytes(data)
 
     @staticmethod
     def assert_span_fits(data: bytes, start: int, end: int) -> None:
@@ -150,6 +162,91 @@ class ReachableSourceTest(unittest.TestCase):
         self.assertIn("0x2F", owned_banks)
         self.assertNotIn("0x22", owned_banks)
 
+    def test_reachable_tools_source_is_scanned_by_every_manifest_scanner(
+        self,
+    ) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm", 'incsrc "Tools/reachable.asm"\n'
+        )
+        self.fixture.write_text(
+            "Tools/reachable.asm",
+            "org $008100\n"
+            "JSL ReachableToolsHook\n"
+            "org $01CC18 : JML ReachableToolsTag ; @hook name=ToolsTag\n"
+            "org $2F8000\n"
+            "db $00\n",
+        )
+
+        manifest = generate_manifest(self.fixture.root)
+        owned_banks = {
+            entry["bank"] for entry in manifest["owned_banks"]["banks"]
+        }
+
+        self.assertEqual(manifest["summary"]["total_hooks"], 3)
+        self.assertIn("0x2F", owned_banks)
+        self.assertTrue(
+            any(
+                tag["name"] == "ToolsTag"
+                for tag in manifest["room_tags"]["tags"]
+            )
+        )
+
+    def test_fastrom_orgs_map_to_physical_spans_not_mirror_banks(self) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm", 'incsrc "Core/active.asm"\n'
+        )
+        self.fixture.write_text(
+            "Core/active.asm",
+            "org $808B6B : LDX.w #$6040\n"
+            "org $20AF20\n"
+            "db $00\n"
+            "org $A0F000\n"
+            "db $00\n",
+        )
+
+        manifest = generate_manifest(self.fixture.root)
+        protected = manifest["protected_regions"]["regions"]
+        banks = {
+            entry["bank"]: entry for entry in manifest["owned_banks"]["banks"]
+        }
+
+        self.assertEqual(protected[0]["start"], "0x008B6B")
+        self.assertNotIn("0x80", banks)
+        self.assertNotIn("0xA0", banks)
+        self.assertEqual(banks["0x20"]["ownership"], "shared")
+        self.assertEqual(
+            {
+                region["start"] for region in banks["0x20"]["regions"]
+            },
+            {"0x20AF20", "0x20F000"},
+        )
+
+
+class RepositorySourceRegressionTest(unittest.TestCase):
+    def test_real_fastrom_orgs_use_physical_manifest_ranges(self) -> None:
+        manifest = generate_manifest(REPO_ROOT)
+        protected_starts = {
+            region["start"]
+            for region in manifest["protected_regions"]["regions"]
+        }
+        banks = {
+            entry["bank"]: entry for entry in manifest["owned_banks"]["banks"]
+        }
+
+        self.assertIn("0x008B6B", protected_starts)
+        self.assertIn("0x06F725", protected_starts)
+        self.assertIn("0x0DDFB2", protected_starts)
+        self.assertFalse(
+            {"0x80", "0x86", "0x8D", "0xA0"} & banks.keys()
+        )
+        self.assertTrue(
+            any(
+                region["start"] == "0x20F000"
+                and region["source"] == "Overworld/lost_woods.asm:27"
+                for region in banks["0x20"]["regions"]
+            )
+        )
+
 
 class EditorManagedRegionsTest(unittest.TestCase):
     def setUp(self) -> None:
@@ -195,6 +292,55 @@ class EditorManagedRegionsTest(unittest.TestCase):
         with self.assertRaisesRegex(
             ManifestGenerationError,
             "Room-header pointers are not unique",
+        ):
+            derive_editor_managed_regions(rom_path)
+
+    def test_low_half_header_table_pointer_fails_closed(self) -> None:
+        rom_path = self.fixture.write_dev_rom()
+        self.fixture.write_rom_value(
+            rom_path, ROOM_HEADER_POINTER_PC, 0x220000, 3
+        )
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            "Room-header pointer-table operand "
+            "0x220000 is not a high-half LoROM pointer",
+        ):
+            derive_editor_managed_regions(rom_path)
+
+    def test_wram_header_table_pointer_fails_closed(self) -> None:
+        rom_path = self.fixture.write_dev_rom()
+        self.fixture.write_rom_value(
+            rom_path, ROOM_HEADER_POINTER_PC, 0x7E8000, 3
+        )
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            "Room-header pointer-table operand 0x7E8000 points to WRAM",
+        ):
+            derive_editor_managed_regions(rom_path)
+
+    def test_low_half_room_header_pointer_fails_closed(self) -> None:
+        rom_path = self.fixture.write_dev_rom()
+        self.fixture.write_rom_value(rom_path, 0x110000, 0x0280, 2)
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            "Room-header pointer for room 0x000 "
+            "0x220280 is not a high-half LoROM pointer",
+        ):
+            derive_editor_managed_regions(rom_path)
+
+    def test_wram_room_header_bank_fails_closed(self) -> None:
+        rom_path = self.fixture.write_dev_rom()
+        self.fixture.write_rom_value(
+            rom_path, ROOM_HEADER_BANK_PC, 0x7E, 1
+        )
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            "Room-header pointer for room 0x000 "
+            "0x7E8280 points to WRAM",
         ):
             derive_editor_managed_regions(rom_path)
 

--- a/Scripts/Generate/tests/test_generate_hack_manifest.py
+++ b/Scripts/Generate/tests/test_generate_hack_manifest.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+GENERATE_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(GENERATE_DIR))
+
+from generate_hack_manifest import (  # noqa: E402
+    DUNGEON_MESSAGE_IDS_PC,
+    DUNGEON_ROOM_COUNT,
+    ROOM_HEADER_BANK_PC,
+    ROOM_HEADER_POINTER_PC,
+    ManifestGenerationError,
+    _pc_to_snes,
+    collect_reachable_asm_sources,
+    compute_protected_regions,
+    derive_editor_managed_regions,
+    generate_manifest,
+)
+from generate_hooks_json import HookEntry  # noqa: E402
+
+
+class ManifestFixture:
+    def __init__(self) -> None:
+        self._temp = tempfile.TemporaryDirectory()
+        self.root = Path(self._temp.name)
+
+    def close(self) -> None:
+        self._temp.cleanup()
+
+    def write_text(self, relative: str, text: str) -> Path:
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    def write_dev_rom(self, duplicate_room: int | None = None) -> Path:
+        data = bytearray(0x120000)
+        header_table_pc = 0x110000
+        header_table_snes = _pc_to_snes(header_table_pc)
+        data[ROOM_HEADER_POINTER_PC:ROOM_HEADER_POINTER_PC + 3] = (
+            header_table_snes.to_bytes(3, "little")
+        )
+        data[ROOM_HEADER_BANK_PC] = 0x22
+
+        first_header_offset = 0x8280
+        for room_id in range(DUNGEON_ROOM_COUNT):
+            source_room = (
+                duplicate_room - 1
+                if duplicate_room is not None and room_id == duplicate_room
+                else room_id
+            )
+            header_offset = first_header_offset + source_room * 14
+            pointer_pc = header_table_pc + room_id * 2
+            data[pointer_pc:pointer_pc + 2] = header_offset.to_bytes(
+                2, "little"
+            )
+
+        message_end = DUNGEON_MESSAGE_IDS_PC + DUNGEON_ROOM_COUNT * 2
+        self.assert_span_fits(data, DUNGEON_MESSAGE_IDS_PC, message_end)
+
+        rom_path = self.root / "Roms" / "oos168.sfc"
+        rom_path.parent.mkdir(parents=True, exist_ok=True)
+        rom_path.write_bytes(data)
+        return rom_path
+
+    @staticmethod
+    def assert_span_fits(data: bytes, start: int, end: int) -> None:
+        if not 0 <= start < end <= len(data):
+            raise AssertionError(
+                f"Fixture span [0x{start:X}, 0x{end:X}) does not fit"
+            )
+
+
+class ReachableSourceTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fixture = ManifestFixture()
+
+    def tearDown(self) -> None:
+        self.fixture.close()
+
+    def test_collects_nested_and_root_relative_includes(self) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm",
+            'incsrc "Core/active.asm"\n'
+            '; incsrc "Core/commented.asm"\n',
+        )
+        self.fixture.write_text(
+            "Core/active.asm",
+            "incsrc nested.asm ; relative to this file\n",
+        )
+        self.fixture.write_text(
+            "Core/nested.asm",
+            'incsrc "Shared/root.asm"\n',
+        )
+        self.fixture.write_text("Shared/root.asm", "org $2F8000\n")
+        self.fixture.write_text("Core/commented.asm", "org $228080\n")
+
+        sources = {
+            path.relative_to(self.fixture.root.resolve()).as_posix()
+            for path in collect_reachable_asm_sources(self.fixture.root)
+        }
+
+        self.assertEqual(
+            sources,
+            {
+                "Oracle_main.asm",
+                "Core/active.asm",
+                "Core/nested.asm",
+                "Shared/root.asm",
+            },
+        )
+
+    def test_unresolved_reachable_include_fails_closed(self) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm", 'incsrc "Core/missing.asm"\n'
+        )
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            r"Oracle_main\.asm:1: unresolved incsrc 'Core/missing\.asm'",
+        ):
+            collect_reachable_asm_sources(self.fixture.root)
+
+    def test_manifest_excludes_unreachable_bank_claims_and_hooks(self) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm", 'incsrc "Core/active.asm"\n'
+        )
+        self.fixture.write_text(
+            "Core/active.asm",
+            "org $2F8000\n"
+            "db $00\n",
+        )
+        self.fixture.write_text(
+            "Dungeons/Assets/Wagon Cart/WagonCart.asm",
+            "org $228080\n"
+            "db $00\n",
+        )
+
+        manifest = generate_manifest(self.fixture.root)
+        owned_banks = {
+            entry["bank"] for entry in manifest["owned_banks"]["banks"]
+        }
+
+        self.assertEqual(manifest["manifest_version"], 3)
+        self.assertEqual(manifest["summary"]["total_hooks"], 1)
+        self.assertIn("0x2F", owned_banks)
+        self.assertNotIn("0x22", owned_banks)
+
+
+class EditorManagedRegionsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fixture = ManifestFixture()
+        self.fixture.write_text("Oracle_main.asm", "")
+
+    def tearDown(self) -> None:
+        self.fixture.close()
+
+    def test_derives_exact_room_header_and_message_ranges(self) -> None:
+        rom_path = self.fixture.write_dev_rom()
+
+        regions = derive_editor_managed_regions(rom_path)
+
+        self.assertEqual(
+            regions,
+            [
+                {"start": "0x228280", "end": "0x2292B0"},
+                {"start": "0x07F61D", "end": "0x07F86D"},
+            ],
+        )
+
+    def test_manifest_v3_includes_derived_editor_ranges(self) -> None:
+        self.fixture.write_dev_rom()
+
+        manifest = generate_manifest(self.fixture.root)
+
+        self.assertEqual(manifest["manifest_version"], 3)
+        self.assertEqual(
+            manifest["build_pipeline"]["entry_point"], "Oracle_main.asm"
+        )
+        self.assertEqual(
+            manifest["editor_managed_regions"]["regions"],
+            [
+                {"start": "0x228280", "end": "0x2292B0"},
+                {"start": "0x07F61D", "end": "0x07F86D"},
+            ],
+        )
+
+    def test_duplicate_room_header_pointer_fails_closed(self) -> None:
+        rom_path = self.fixture.write_dev_rom(duplicate_room=1)
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            "Room-header pointers are not unique",
+        ):
+            derive_editor_managed_regions(rom_path)
+
+    def test_manifest_v3_canonicalizes_legacy_low_half_hook(self) -> None:
+        hook = HookEntry(
+            address=0x1E7F21,
+            name="ArrghusHook",
+            kind="patch",
+            target=None,
+            source="Sprites/Bosses/arrghus.asm:3",
+            module="Sprites",
+        )
+
+        regions = compute_protected_regions([hook])
+
+        self.assertEqual(regions[0]["start"], "0x1EFF21")
+        self.assertEqual(regions[0]["end"], "0x1EFF25")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Sprites/all_sprites.asm
+++ b/Sprites/all_sprites.asm
@@ -291,7 +291,7 @@ incsrc "Sprites/Bosses/lanmola.asm"
 %log_end("lanmola", !LOG_DUNGEON)
 
 %log_start("lanmola_expanded", !LOG_DUNGEON)
-incsrc "Sprites/Bosses/lanmola_Expanded.asm"
+incsrc "Sprites/Bosses/lanmola_expanded.asm"
 %log_end("lanmola_expanded", !LOG_DUNGEON)
 
 %log_start("followers", !LOG_DUNGEON)


### PR DESCRIPTION
## Summary
- derive ASM ownership from the literal `incsrc` graph rooted at `Oracle_main.asm` instead of scanning unreachable assets
- prune disabled module include edges before traversal, including cross-root descendants, while retaining independently active sources
- canonicalize reachable FastROM hook addresses to physical LoROM spans without turning mirror banks into whole-bank ownership
- derive exact manifest-v3 dungeon header and message-ID editor ranges from the live ROM with strict pointer/layout validation
- add focused generator tests and a `Scripts/**` / ASM-triggered CI workflow

## Why
The generated manifest falsely treated unreachable `Dungeons/Assets/Wagon Cart/WagonCart.asm` as active and claimed all of bank `$22`. That blocked legitimate yaze room-header writes even though the current build has no active ASM collision there. The generator now follows the same reachable module graph as the build and fails closed on malformed includes, pointers, or layouts.

## Validation
- `Scripts/Generate/tests/test_generate_hack_manifest.py`: 18/18 passed
- independent strict review found and verified fixes for FastROM mirror ownership, explicit-source skip leakage, low-half/WRAM pointer acceptance, inactive-module provenance, and CI trigger coverage
- Linux CI exposed and now pins case-exact `incsrc` resolution; the Lanmola include matches its tracked lowercase filename
- `ruff` (two pre-existing F841 exclusions), `pycodestyle`, `py_compile`, `actionlint`, and `git diff --check`: passed
- live read-only generation: 535 hooks, 389 protected regions, 24 owned banks; unreachable bank `$22` ownership absent and reachable bank `$2F` ownership retained
- exact editor ranges derived as `$22:8280-$22:92B0` for 296 room headers and `$07:F61D-$07:F86D` for message IDs
- downstream z3ed parsed manifest v3 and project/manifest/hash verification passed 7/7
- canonical `oos168.sfc` SHA-256 remained `d289b2408c3ccc312abeadf274f04f475106034fcab8ebff3f307fd229db4799`

## Boundaries
- no ROM or generated manifest is committed
- no canonical ROM was modified
- the 205-file dirty primary Oracle checkout was not touched; all work was done in a clean worktree
- dungeon stream layout metadata remains separate work

Closes #110

