### PR TITLE
Reconcile message bridge integration settings

### DIFF
--- a/Docs/Planning/Status/2026-07-31_message_bridge_integration_state.md
+++ b/Docs/Planning/Status/2026-07-31_message_bridge_integration_state.md
@@ -1,0 +1,74 @@
+# Message-Bridge Integration State — 2026-07-31
+
+Purpose: exact reconciliation map for syncing the local checkout with
+origin/master (11 commits: PR #114 manifest reachability, PR #115 message
+source contract). Written for the clean integration pass; verified against
+`origin/master` by direct inspection, not from PR descriptions.
+
+## Upstream facts (verified)
+
+1. Expanded messages are source-owned: `Data/dialogue/expanded_messages.json`
+   (109 expanded / 0 vanilla, format `yaze-message-bundle`) generates
+   `Core/Generated/expanded_messages.asm`. Do not hand-edit the generated file.
+2. Bank $2F allocation, enforced by build-failing asserts:
+   - `$2F8000-$2F8025` — MessageExpand loader (`Core/message.asm`)
+   - `$2F8026-$2FFDFF` — expanded message data (32,218 bytes; bundle currently
+     13,676 bytes ≈ 42% used)
+   - `$2FFE00-$2FFFFF` — progression helpers tail (`Core/progression.asm`,
+     est. 100–200 bytes used of 512)
+   Overflow anywhere fails the build. This is the "detect when full" guarantee.
+3. `build_rom.sh` now runs `validate_expanded_message_source.py --root` before
+   assembling and regenerates `Roms/hack_manifest.json` after. Both fail closed.
+4. CI: `.github/workflows/manifest-tests.yml` runs
+   `Scripts/Generate/tests/` (unittest discover) on ASM/bundle/script changes.
+5. `.gitignore` adds `.yaze-message-source-sync.lock`; `.gitattributes` pins LF
+   on the bundle and generated ASM.
+
+## Conflict surface: 4 files dirty locally AND changed upstream
+
+| File | Disposition |
+|---|---|
+| `Docs/Planning/Plans/essence_maiden_presentation.md` | Take upstream. Local edit is a path fix upstream already includes. |
+| `Oracle-of-Secrets.yaze` | Keep local. Upstream's two changes (`hack_manifest_file=Roms/hack_manifest.json`, `expected_hash=eaf2ce3d...`) are already in the local copy with identical values. Local-only lines are deliberate safety state: `labels_filename=` cleared, `save_dungeon_maps=false`, `save_graphics_sheet=false`, `autosave_enabled=false`. It also points `[build] build_script` at the tracked `./Scripts/Build/build_rom.sh 168`; upstream's `./run.sh` does not exist. |
+| `Scripts/Build/build_rom.sh` | Take upstream, then re-apply 3 local-only deltas (below). Do NOT re-apply `--dev-rom`. |
+| `Scripts/Generate/generate_hack_manifest.py` | Take upstream wholesale. Local copy is an intermediate draft of the same work; upstream version is covered by 552 lines of tests + CI. |
+
+## Local-only build_rom.sh deltas worth preserving
+
+1. Base-ROM preference swap: prefer `Roms/oos168.sfc` over legacy
+   `oos168_test2.sfc` (upstream still picks legacy first).
+2. Legacy-ROM message downgraded from WARNING to
+   `NOTE: Ignoring legacy base ROM ...`.
+3. z3dk analyzer paths lowercased: `../z3dk/scripts/` (upstream has
+   `../z3dk/Scripts/`, wrong on case-sensitive filesystems).
+
+Dropped delta: local manifest call passes `--dev-rom "$base_rom"` — upstream
+generator has no `--dev-rom` flag (accepts `--root`, `--output`, `--rom`,
+`--pretty`, `--compact`). Carrying it forward breaks the build.
+
+## Other verified upstream details
+
+- `Sprites/all_sprites.asm`: include case fix
+  `lanmola_Expanded.asm` → `lanmola_expanded.asm` (fallout of case-exact
+  manifest reachability; required on case-sensitive filesystems).
+- `Docs/Planning/Plans/essence_maiden_presentation.md` upstream rewrite is
+  workflow-only. No story-canon content added; no Ganondorf-origin or
+  two-villain material.
+- Vanilla message slots (e.g. Farore intro at $0E) are NOT in the bundle
+  (`vanilla: 0`); they go through the yaze/z3ed vanilla message path
+  (yaze PR #178 preflight/readback).
+
+## yaze side (as of 2026-07-31 ~18:20Z)
+
+- Merged: #166–#181 (message bridge #176–178, palette guards #179–180,
+  BG render routing report #181).
+- Open: #182 (Object Tile Editor write guards, retargeted to master, awaiting
+  CI), #183 (provenance for dungeon object tile writes).
+
+## Open items
+
+1. Integration pass itself (Codex owns; no stash/pull/pop on this checkout).
+2. OoS PR #107 still open — scawful decides.
+3. Dialogue text-debt batch can move to `expanded_messages.json` once synced.
+4. Watch progression tail headroom if reaction tables grow (512-byte cap,
+   assert-protected).

--- a/Oracle-of-Secrets.yaze
+++ b/Oracle-of-Secrets.yaze
@@ -22,7 +22,7 @@ rom_backup_folder=Backups
 code_folder=Core
 assets_folder=Sprites
 patches_folder=Core
-labels_filename=labels.txt
+labels_filename=
 symbols_filename=Roms/oos168x.sym
 output_folder=Roms
 custom_objects_folder=Dungeons/Objects/Data
@@ -37,15 +37,15 @@ write_policy=block
 [feature_flags]
 load_custom_overworld=true
 apply_zs_custom_overworld_asm=true
-save_dungeon_maps=true
-save_graphics_sheet=true
+save_dungeon_maps=false
+save_graphics_sheet=false
 enable_custom_objects=true
 
 [workspace]
 font_global_scale=1
 dark_mode=true
 ui_theme=default
-autosave_enabled=true
+autosave_enabled=false
 autosave_interval_secs=300
 backup_on_save=true
 show_grid=true
@@ -85,7 +85,7 @@ enable_tool_emulator=true
 builder_blueprint_path=
 
 [build]
-build_script=./run.sh
+build_script=./Scripts/Build/build_rom.sh 168
 output_folder=Roms
 git_repository=.
 track_changes=true

--- a/Scripts/Build/build_rom.sh
+++ b/Scripts/Build/build_rom.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 usage() {
   echo "Usage: $(basename "$0") <version> [asar_binary] [--reload] [--no-symbols] [--mesen-sync] [--skip-tests] [--asar=<path>] [--enable <csv>] [--disable <csv>] [--profile <defaults|all-on|all-off>] [--persist-flags]" >&2
   echo "Base ROM: Roms/oos<version>.sfc (unpatched edit target; override with OOS_BASE_ROM)." >&2
-  echo "  Backward compat: if Roms/oos<version>_test2.sfc exists it is used until renamed." >&2
+  echo "  Backward compat: Roms/oos<version>_test2.sfc is used only when the standard base is absent." >&2
   echo "" >&2
   echo "Feature flag overrides:" >&2
   echo "  --enable  <csv>   Comma-separated feature names to enable (e.g. water_gate_hooks, ENABLE_WATER_GATE_HOOKS)." >&2
@@ -136,11 +136,11 @@ fi
 default_base="$rom_dir/oos${version}.sfc"
 legacy_base="$rom_dir/oos${version}_test2.sfc"
 if [[ -z "${OOS_BASE_ROM:-}" ]]; then
-  if [[ -f "$legacy_base" ]]; then
+  if [[ -f "$default_base" ]]; then
+    base_rom="$default_base"
+  elif [[ -f "$legacy_base" ]]; then
     base_rom="$legacy_base"
     echo "NOTE: Using legacy base ROM name $(basename "$legacy_base"). Rename to $(basename "$default_base") to adopt standard naming." >&2
-  elif [[ -f "$default_base" ]]; then
-    base_rom="$default_base"
   else
     echo "ERROR: Base ROM not found. Expected $default_base (or legacy $legacy_base)" >&2
     exit 1
@@ -155,7 +155,7 @@ mlb_rel="Roms/oos${version}x.mlb"
 mlb_path="$rom_dir/oos${version}x.mlb"
 
 if [[ -f "$legacy_base" && "$base_rom" != "$legacy_base" ]]; then
-  echo "WARNING: $legacy_base exists but base ROM is $base_rom (OOS_BASE_ROM override?)" >&2
+  echo "NOTE: Ignoring legacy base ROM $legacy_base; using $base_rom" >&2
 fi
 
 if [[ ! -f "$base_rom" ]]; then
@@ -420,8 +420,8 @@ fi
 
 if [[ -f "$hooks_json" && -f "$patched_rom" ]]; then
   echo "[*] Running static analysis..."
-  z3dk_analyzer="$repo_root/../z3dk/Scripts/static_analyzer.py"
-  oracle_analyzer="$repo_root/../z3dk/Scripts/oracle_analyzer.py"
+  z3dk_analyzer="$repo_root/../z3dk/scripts/static_analyzer.py"
+  oracle_analyzer="$repo_root/../z3dk/scripts/oracle_analyzer.py"
 
   # Prefer oracle-specific analyzer, fall back to generic
   if [[ -f "$oracle_analyzer" ]]; then


### PR DESCRIPTION
## Summary

- reconcile the local Yaze project safety settings with the merged message-source/manifest contracts
- make the canonical `Roms/oos168.sfc` win over the legacy `_test2` base while retaining fallback compatibility
- keep build diagnostics and lowercase z3dk analyzer paths accurate on case-sensitive filesystems
- record the exact keep/drop integration map, including why the unsupported local `--dev-rom` draft was not carried forward

## Why

PRs #114 and #115 superseded intermediate local drafts in the dirty working checkout. This branch reconstructs only the reviewed local deltas on top of current `origin/master`, without stash/pull/pop or modification of the dirty primary checkout.

The project descriptor deliberately keeps dungeon-map, graphics-sheet, and autosave writes disabled; custom objects remain enabled, and the tracked build entrypoint is `./Scripts/Build/build_rom.sh 168` rather than the nonexistent `./run.sh`.

## Verification

- `bash -n Scripts/Build/build_rom.sh`
- project descriptor contract parsed successfully
- `python3 -m unittest discover -s Scripts/Generate/tests -p 'test_*.py'`: 34/34 passed
- `validate_expanded_message_source.py --root .`: 109 messages, 13,676 bytes, expected source hash
- `git diff --check`
- independent strict review found no blocker

## Residual risk

No full ROM build/readback ran in this clean worktree because it intentionally contains no ignored base ROM. The canonical base in the protected local checkout hashes to the descriptor value, but it was not copied or built here.

`generate_hack_manifest.py` still assumes the canonical `Roms/oos168.sfc` for dev-ROM metadata; explicit legacy/`OOS_BASE_ROM` manifest provenance needs a separate supported CLI change. The removed `--dev-rom` draft must not be restored because the merged generator does not accept it.
