### PR TITLE
Track selected ROMs in hack manifests

### DIFF
--- a/Docs/Planning/Status/2026-07-31_message_bridge_integration_state.md
+++ b/Docs/Planning/Status/2026-07-31_message_bridge_integration_state.md
@@ -42,9 +42,15 @@ source contract). Written for the clean integration pass; verified against
 3. z3dk analyzer paths lowercased: `../z3dk/scripts/` (upstream has
    `../z3dk/Scripts/`, wrong on case-sensitive filesystems).
 
-Dropped delta: local manifest call passes `--dev-rom "$base_rom"` — upstream
-generator has no `--dev-rom` flag (accepts `--root`, `--output`, `--rom`,
-`--pretty`, `--compact`). Carrying it forward breaks the build.
+Dropped integration delta: the local manifest call passed
+`--dev-rom "$base_rom"`, but the upstream generator at integration time had no
+such flag. Carrying that call-only hunk forward would have broken the build.
+
+Follow-up resolution: the old call-only draft remains intentionally dropped.
+The manifest provenance follow-up implements `--dev-rom` as a validated
+generator option, passes the exact base selected by `build_rom.sh`, and covers
+canonical, legacy, external, and missing-ROM cases with tests. Only that paired
+generator + build-script contract is safe to use.
 
 ## Other verified upstream details
 

--- a/Scripts/Build/build_rom.sh
+++ b/Scripts/Build/build_rom.sh
@@ -154,13 +154,16 @@ symbols_path="$rom_dir/oos${version}x.sym"
 mlb_rel="Roms/oos${version}x.mlb"
 mlb_path="$rom_dir/oos${version}x.mlb"
 
-if [[ -f "$legacy_base" && "$base_rom" != "$legacy_base" ]]; then
-  echo "NOTE: Ignoring legacy base ROM $legacy_base; using $base_rom" >&2
-fi
-
 if [[ ! -f "$base_rom" ]]; then
   echo "ERROR: Base ROM not found: $base_rom" >&2
   exit 1
+fi
+if [[ "$base_rom" != /* ]]; then
+  base_rom="$(cd "$(dirname "$base_rom")" && pwd -P)/$(basename "$base_rom")"
+fi
+
+if [[ -f "$legacy_base" && "$base_rom" != "$legacy_base" ]]; then
+  echo "NOTE: Ignoring legacy base ROM $legacy_base; using $base_rom" >&2
 fi
 echo "Using base ROM: $base_rom"
 
@@ -349,6 +352,7 @@ echo "[*] Generating Yaze hack manifest..."
 python3 "$repo_root/Scripts/Generate/generate_hack_manifest.py" \
   --root "$repo_root" \
   --output "$repo_root/Roms/hack_manifest.json" \
+  --dev-rom "$base_rom" \
   --rom "$patched_rom"
 
 # Export symbols for yaze + Mesen2.

--- a/Scripts/Generate/generate_hack_manifest.py
+++ b/Scripts/Generate/generate_hack_manifest.py
@@ -996,11 +996,46 @@ def derive_editor_managed_regions(dev_rom_path: Path) -> list[dict]:
 # Main manifest generation
 # ---------------------------------------------------------------------------
 
-def generate_manifest(root: Path, rom_path: Optional[Path] = None) -> dict:
+def _resolve_repo_path(root: Path, path: Path) -> Path:
+    """Resolve a CLI/API path relative to the Oracle repository root."""
+    return (root / path).resolve() if not path.is_absolute() else path.resolve()
+
+
+def _manifest_path(root: Path, path: Path) -> str:
+    """Prefer portable repo-relative manifest paths when possible."""
+    return (
+        path.relative_to(root).as_posix()
+        if path.is_relative_to(root)
+        else str(path)
+    )
+
+
+def generate_manifest(
+    root: Path,
+    rom_path: Optional[Path] = None,
+    dev_rom_path: Optional[Path] = None,
+) -> dict:
     """Generate the complete hack manifest."""
     import hashlib
 
     root = root.resolve()
+    if rom_path is not None:
+        rom_path = _resolve_repo_path(root, rom_path)
+        if not rom_path.is_file():
+            raise ManifestGenerationError(
+                f"Patched ROM not found: {rom_path}"
+            )
+
+    explicit_dev_rom = dev_rom_path is not None
+    dev_rom_path = _resolve_repo_path(
+        root,
+        dev_rom_path or Path("Roms/oos168.sfc"),
+    )
+    if explicit_dev_rom and not dev_rom_path.is_file():
+        raise ManifestGenerationError(
+            f"Editable dev ROM not found: {dev_rom_path}"
+        )
+
     reachable_sources = collect_reachable_asm_sources(root)
 
     # Load defines for conditional compilation evaluation
@@ -1024,8 +1059,12 @@ def generate_manifest(root: Path, rom_path: Optional[Path] = None) -> dict:
     # Build pipeline model
     manifest["build_pipeline"] = {
         "description": "Yaze edits the dev ROM; asar patches it to produce the patched ROM. They share the same base file.",
-        "dev_rom": "Roms/oos168.sfc",
-        "patched_rom": "Roms/oos168x.sfc",
+        "dev_rom": _manifest_path(root, dev_rom_path),
+        "patched_rom": (
+            _manifest_path(root, rom_path)
+            if rom_path is not None
+            else "Roms/oos168x.sfc"
+        ),
         "assembler": "asar",
         "entry_point": str(MANIFEST_ENTRY_POINT),
         "build_script": "Scripts/Build/build_rom.sh",
@@ -1041,22 +1080,26 @@ def generate_manifest(root: Path, rom_path: Optional[Path] = None) -> dict:
     # ROM metadata (patched ROM for verification, dev ROM for editing)
     rom_meta: dict = {}
     if rom_path and rom_path.exists():
-        rom_meta["path"] = str(rom_path.relative_to(root)) if rom_path.is_relative_to(root) else str(rom_path)
+        rom_meta["path"] = _manifest_path(root, rom_path)
         try:
             data = rom_path.read_bytes()
             rom_meta["sha1"] = hashlib.sha1(data).hexdigest()
             rom_meta["size"] = len(data)
-        except Exception:
-            pass
-    # Also hash the dev ROM if it exists
-    dev_rom_path = root / "Roms" / "oos168.sfc"
+        except OSError as exc:
+            raise ManifestGenerationError(
+                f"Unable to read patched ROM {rom_path}: {exc}"
+            ) from exc
+
+    # Also hash the exact editable ROM selected by the build, if it exists.
     if dev_rom_path.exists():
         try:
             dev_data = dev_rom_path.read_bytes()
             rom_meta["dev_rom_sha1"] = hashlib.sha1(dev_data).hexdigest()
             rom_meta["dev_rom_size"] = len(dev_data)
-        except Exception:
-            pass
+        except OSError as exc:
+            raise ManifestGenerationError(
+                f"Unable to read editable dev ROM {dev_rom_path}: {exc}"
+            ) from exc
     manifest["rom"] = rom_meta
 
     if dev_rom_path.exists():
@@ -1194,8 +1237,18 @@ def main() -> int:
     parser.add_argument(
         "--rom",
         type=Path,
-        default=Path("Roms/oos168x.sfc"),
-        help="ROM path for metadata (optional)",
+        help=(
+            "Patched ROM path for metadata "
+            "(default: Roms/oos168x.sfc when present)"
+        ),
+    )
+    parser.add_argument(
+        "--dev-rom",
+        type=Path,
+        help=(
+            "Editable base ROM selected by the build "
+            "(default: Roms/oos168.sfc)"
+        ),
     )
     parser.add_argument(
         "--pretty",
@@ -1213,12 +1266,13 @@ def main() -> int:
     root = args.root.resolve()
     output = (root / args.output).resolve() if not args.output.is_absolute() else args.output
 
-    rom_path = (root / args.rom).resolve() if not args.rom.is_absolute() else args.rom
-    if not rom_path.exists():
-        rom_path = None
+    rom_path = args.rom
+    if rom_path is None:
+        default_rom_path = root / "Roms" / "oos168x.sfc"
+        rom_path = default_rom_path if default_rom_path.is_file() else None
 
     try:
-        manifest = generate_manifest(root, rom_path)
+        manifest = generate_manifest(root, rom_path, args.dev_rom)
     except ManifestGenerationError as exc:
         print(f"error: cannot generate hack manifest: {exc}", file=sys.stderr)
         return 1

--- a/Scripts/Generate/tests/test_generate_hack_manifest.py
+++ b/Scripts/Generate/tests/test_generate_hack_manifest.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import hashlib
+import json
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -429,11 +432,152 @@ class RepositoryMessageSourceTest(unittest.TestCase):
             '--output "$repo_root/Roms/hack_manifest.json"',
             build,
         )
+        self.assertIn('if [[ "$base_rom" != /* ]]', build)
+        self.assertIn(
+            'base_rom="$(cd "$(dirname "$base_rom")" && pwd -P)/'
+            '$(basename "$base_rom")"',
+            build,
+        )
+        self.assertEqual(build.count('--dev-rom "$base_rom"'), 1)
         self.assertIn('--rom "$patched_rom"', build)
         self.assertLess(
             build.index('echo "Built patched ROM: $patched_rom"'),
             build.index(generator_call),
         )
+
+
+class DevRomProvenanceTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fixture = ManifestFixture()
+        self.fixture.write_text("Oracle_main.asm", "")
+        self.canonical = self.fixture.write_dev_rom()
+
+    def tearDown(self) -> None:
+        self.fixture.close()
+
+    def write_distinct_rom(self, path: Path) -> Path:
+        data = bytearray(self.canonical.read_bytes())
+        data[-1] ^= 0xA5
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+        return path
+
+    def test_selected_legacy_rom_drives_pipeline_hash_and_ranges(self) -> None:
+        legacy = self.write_distinct_rom(
+            self.fixture.root / "Roms" / "oos168_test2.sfc"
+        )
+        self.fixture.write_rom_value(
+            legacy, ROOM_HEADER_BANK_PC, 0x23, 1
+        )
+
+        manifest = generate_manifest(
+            self.fixture.root,
+            dev_rom_path=Path("Roms/oos168_test2.sfc"),
+        )
+
+        self.assertEqual(
+            manifest["build_pipeline"]["dev_rom"],
+            "Roms/oos168_test2.sfc",
+        )
+        self.assertEqual(
+            manifest["rom"]["dev_rom_sha1"],
+            hashlib.sha1(legacy.read_bytes()).hexdigest(),
+        )
+        self.assertNotEqual(
+            manifest["rom"]["dev_rom_sha1"],
+            hashlib.sha1(self.canonical.read_bytes()).hexdigest(),
+        )
+        self.assertEqual(
+            manifest["rom"]["dev_rom_size"], legacy.stat().st_size
+        )
+        self.assertEqual(
+            manifest["editor_managed_regions"]["regions"],
+            [
+                {"start": "0x238280", "end": "0x2392B0"},
+                {"start": "0x07F61D", "end": "0x07F86D"},
+            ],
+        )
+
+    def test_external_dev_rom_uses_absolute_manifest_path(self) -> None:
+        with tempfile.TemporaryDirectory() as external_dir:
+            external = self.write_distinct_rom(
+                Path(external_dir) / "override.sfc"
+            ).resolve()
+
+            manifest = generate_manifest(
+                self.fixture.root,
+                dev_rom_path=external,
+            )
+
+            self.assertEqual(
+                manifest["build_pipeline"]["dev_rom"], str(external)
+            )
+            self.assertEqual(
+                manifest["rom"]["dev_rom_sha1"],
+                hashlib.sha1(external.read_bytes()).hexdigest(),
+            )
+
+    def test_explicit_missing_dev_rom_fails_closed(self) -> None:
+        missing = Path("Roms/missing.sfc")
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            "Editable dev ROM not found:.*Roms/missing.sfc",
+        ):
+            generate_manifest(
+                self.fixture.root,
+                dev_rom_path=missing,
+            )
+
+    def test_explicit_missing_patched_rom_fails_closed(self) -> None:
+        missing = Path("Roms/missing-patched.sfc")
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            "Patched ROM not found:.*Roms/missing-patched.sfc",
+        ):
+            generate_manifest(
+                self.fixture.root,
+                rom_path=missing,
+            )
+
+    def test_cli_records_selected_dev_and_patched_rom_paths(self) -> None:
+        legacy = self.write_distinct_rom(
+            self.fixture.root / "Roms" / "oos168_test2.sfc"
+        )
+        patched = self.fixture.root / "Roms" / "oos169x.sfc"
+        patched.write_bytes(b"patched-rom")
+        output = self.fixture.root / "Roms" / "hack_manifest.json"
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(GENERATE_DIR / "generate_hack_manifest.py"),
+                "--root",
+                str(self.fixture.root),
+                "--output",
+                str(output),
+                "--dev-rom",
+                str(legacy),
+                "--rom",
+                str(patched),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        manifest = json.loads(output.read_text(encoding="utf-8"))
+        self.assertEqual(
+            manifest["build_pipeline"]["dev_rom"],
+            "Roms/oos168_test2.sfc",
+        )
+        self.assertEqual(
+            manifest["build_pipeline"]["patched_rom"],
+            "Roms/oos169x.sfc",
+        )
+        self.assertEqual(manifest["rom"]["path"], "Roms/oos169x.sfc")
 
 
 class EditorManagedRegionsTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- add a supported, fail-closed `--dev-rom` manifest-generator contract
- pass the exact canonical, legacy, or `OOS_BASE_ROM` base selected by `build_rom.sh`
- derive dev-ROM path/hash/size and editor-managed ranges from that selected file
- derive patched-ROM provenance from `--rom` instead of hardcoding version 168
- keep repo-contained paths portable and preserve external override paths as absolute
- update the integration record so the superseded call-only draft is not confused with this tested paired contract

## Why

The build can select `Roms/oos168.sfc`, the legacy `_test2` fallback, or an explicit override, but the manifest always claimed and analyzed `Roms/oos168.sfc`. Yaze consumes `build_pipeline.dev_rom` as the editable/save target, so that mismatch could attach hashes and editor-managed ranges to the wrong ROM.

This is the supported follow-up to PR #116. It does not restore the old broken hunk that passed an option the generator did not understand; it implements both sides and fails closed for explicit missing dev or patched ROMs.

## Verification

- exact head `854db92622b4a7824b230073eb529e0ff981cf89`
- `bash -n Scripts/Build/build_rom.sh`
- focused manifest tests: 25/25 passed
- full generator/source-contract suite: 39/39 passed
- expanded-message source validator: 109 messages, 13,676 bytes, expected SHA-256
- `git diff --check`
- independent strict read-only review: no blocker after explicit missing patched-ROM handling was tightened

## Residual risk

No real ROM build/readback ran in this clean worktree because it intentionally contains no ignored ROM. Fixture CLI coverage proves the selected dev/patched path, hash, size, range, external-path, and missing-file behavior. The shell wiring check is source-contract based rather than a full build invocation.
