### PR TITLE
feat(manifest): expose minecart track source

### DIFF
--- a/Scripts/Generate/generate_hack_manifest.py
+++ b/Scripts/Generate/generate_hack_manifest.py
@@ -115,6 +115,7 @@ EXPANDED_MESSAGE_ASM_INCLUDE = Path(
 EXPANDED_MESSAGE_BUNDLE = Path("Data/dialogue/expanded_messages.json")
 EXPANDED_MESSAGE_DATA_START = 0x2F8026
 EXPANDED_MESSAGE_DATA_END = 0x2FFDFF
+MINECART_TRACK_SOURCE = Path("Sprites/Objects/data/minecart_tracks.asm")
 DUNGEON_ROOM_COUNT = 296
 ROOM_HEADER_POINTER_PC = 0xB5DD
 ROOM_HEADER_BANK_PC = 0xB5E7
@@ -1170,6 +1171,14 @@ def generate_manifest(
             },
             **messages,
         }
+
+    manifest["minecart_tracks"] = {
+        "source": {
+            "format": "yaze-minecart-track-table",
+            "version": 1,
+            "path": MINECART_TRACK_SOURCE.as_posix(),
+        },
+    }
 
     # Room tags — the dispatch table at $01CC00-$01CC5A is in vanilla bank $01.
     # Asar patches specific 4-byte slots (JML instructions). Yaze's room editor

--- a/Scripts/Generate/tests/test_generate_hack_manifest.py
+++ b/Scripts/Generate/tests/test_generate_hack_manifest.py
@@ -446,6 +446,21 @@ class RepositoryMessageSourceTest(unittest.TestCase):
         )
 
 
+class RepositoryMinecartTrackSourceTest(unittest.TestCase):
+    def test_manifest_exposes_durable_minecart_track_source(self) -> None:
+        manifest = generate_manifest(REPO_ROOT)
+
+        self.assertEqual(manifest["manifest_version"], 3)
+        self.assertEqual(
+            manifest["minecart_tracks"]["source"],
+            {
+                "format": "yaze-minecart-track-table",
+                "version": 1,
+                "path": "Sprites/Objects/data/minecart_tracks.asm",
+            },
+        )
+
+
 class DevRomProvenanceTest(unittest.TestCase):
     def setUp(self) -> None:
         self.fixture = ManifestFixture()


### PR DESCRIPTION
## Summary
- add an additive `minecart_tracks.source` ownership contract to generated hack manifests
- identify the canonical source as `Sprites/Objects/data/minecart_tracks.asm` using `yaze-minecart-track-table` version 1
- keep `manifest_version` at 3 and cover the exact contract with a focused regression test

## Verification
- `python3 -m unittest Scripts.Generate.tests.test_generate_hack_manifest -v` (26 passed)
- `git diff --check`

## Scope
- no ASM source changes
- no ROM generation or edits
- no hand-edited ignored manifest output