### PR TITLE
fix(metadata): use tracked Oracle build entrypoint

### DIFF
--- a/PROJECT.toml
+++ b/PROJECT.toml
@@ -15,7 +15,7 @@ languages = ["asm-65816"]
 build_system = "asar"
 
 [build]
-command = "./build.sh"
+command = "Scripts/Build/build_rom.sh 168"
 
 [dependencies]
 # Build dependencies


### PR DESCRIPTION
## Summary
- point `PROJECT.toml` at the tracked Oracle build script
- replace the nonexistent root `./build.sh` command

## Verification
- parsed `PROJECT.toml` with Python `tomllib`
- resolved the exact argv to `Scripts/Build/build_rom.sh 168`
- confirmed the script exists and is executable
- ran `bash -n Scripts/Build/build_rom.sh`
