### PR TITLE
fix(dungeons): make pendant chest rewards reproducible

### DIFF
--- a/Core/patches.asm
+++ b/Core/patches.asm
@@ -1,6 +1,17 @@
 ; This file contains all direct patches to the original ROM.
 ; It is included from Oracle_main.asm.
 
+; Keep the Shrine pendant rewards reproducible from an unedited base ROM.
+; Guard both the chest record identity and the accepted old/already-fixed item
+; values so a changed chest table fails closed instead of patching a wrong byte.
+assert read2($01E9E6) == $8073, "Room $73 big-chest record moved"
+assert read1($01E9E8) == $39 || read1($01E9E8) == $3A, "Unexpected room $73 big-chest item"
+org $01E9E8 : db $3A ; Pendant of Power
+
+assert read2($01E9F5) == $807A, "Room $7A big-chest record moved"
+assert read1($01E9F7) == $38 || read1($01E9F7) == $39, "Unexpected room $7A big-chest item"
+org $01E9F7 : db $39 ; Pendant of Wisdom
+
 ; =========================================================
 ; JumpTableLocal Guard (Black-Screen Prevention)
 ;


### PR DESCRIPTION
## What changed

- Move the S1/S2 pendant chest correction into `Core/patches.asm`, so a source build owns the reward bytes instead of relying on edits in the gitignored base ROM.
- Guard each write with the expected chest record identity.
- Accept only the known pre-fix or already-fixed item byte, then write the canonical reward:
  - room `$73`: `$39` -> `$3A` (Pendant of Power)
  - room `$7A`: `$38` -> `$39` (Pendant of Wisdom)

This is the focused extraction of commit `3a3a42f` from draft PR #107.

## Why

The local `oos168.sfc` already contains these two corrected bytes, but the correction was not reproducible from Git. A clean build from a pre-fix base could therefore restore the wrong rewards. The assertions also make an unexpected chest-table layout fail closed instead of patching an unrelated byte.

## Verification

- Reconstructed a pre-fix input from local `oos168.sfc` by reverting only the two item bytes (`SHA-256 9a19cc10166ad89fcf26af775b02713edf189c844cd13d9b4a46ef3cb74ac253`).
- `OOS_BACKUP_ROOT=/tmp/oos-pendant-build-backups ./Scripts/Build/build_rom.sh 168`
  - custom-collision and 109-message source contracts passed
  - Oracle menu validation passed with 0 errors / 0 warnings
  - Asar build, manifest generation, symbols, and overlap check completed
- `python3 Scripts/Build/check_zscream_overlap.py` passed.
- Binary readback confirmed record IDs `$8073` / `$807A` were unchanged and output bytes are `$3A` at PC `$00E9E8` and `$39` at PC `$00E9F7`.
- Patched output SHA-256: `fc8590bd382c25ce5c4ad56f08000ad0641768a6090be295e1201e3bcc3664f9` (matches the current local patched build).
- Negative Asar check with an unexpected `$37` item byte failed at the new `$73` assertion with exit 1.

## Known verification gaps

- The build's existing static analyzer reported its non-fatal baseline findings (7,452 errors / 900 warnings); none point to this two-byte patch.
- Emulator smoke tests were skipped because no owned emulator backend was attached. Runtime chest opening remains a follow-up gate before calling the gameplay behavior emulator-verified.
