### PR TITLE
fix(mesen2): resolve launcher paths from repository root

### DIFF
--- a/Scripts/Build/oos-session.sh
+++ b/Scripts/Build/oos-session.sh
@@ -6,7 +6,7 @@ usage() {
 Launch or reuse an isolated Oracle debug instance and jump into a named task.
 
 Usage:
-  Scripts/oos-session.sh <task> [options]
+  Scripts/Build/oos-session.sh <task> [options]
 
 Tasks:
   free        Launch/reuse instance only
@@ -31,14 +31,14 @@ Options:
   -h, --help        Show help
 
 Examples:
-  Scripts/oos-session.sh maku --crystals 3
-  Scripts/oos-session.sh d6 --instance oos-scawful-debug
-  Scripts/oos-session.sh free
+  Scripts/Build/oos-session.sh maku --crystals 3
+  Scripts/Build/oos-session.sh d6 --instance oos-scawful-debug
+  Scripts/Build/oos-session.sh free
 EOF
 }
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 TRUSTED_SEEDS="${ROOT_DIR}/Docs/Debugging/Testing/trusted_state_seeds.json"
 
 task="${1:-}"
@@ -153,7 +153,7 @@ PY
 }
 
 launch_instance() {
-  "${ROOT_DIR}/Scripts/mesen2_launch_instance.sh" \
+  "${ROOT_DIR}/Scripts/Mesen2/mesen2_launch_instance.sh" \
     --reuse \
     --instance "${instance}" \
     --owner "${owner}" \

--- a/Scripts/Mesen2/mesen2_client_lib/bridge.py
+++ b/Scripts/Mesen2/mesen2_client_lib/bridge.py
@@ -20,7 +20,7 @@ def _registry_dir() -> Path:
     override = os.getenv("MESEN2_REGISTRY_DIR")
     if override:
         return Path(override).expanduser().resolve()
-    repo_root = Path(__file__).resolve().parents[2]
+    repo_root = Path(__file__).resolve().parents[3]
     return (repo_root / ".context" / "scratchpad" / "mesen2" / "instances").resolve()
 
 

--- a/Scripts/Mesen2/mesen2_client_lib/cli.py
+++ b/Scripts/Mesen2/mesen2_client_lib/cli.py
@@ -240,7 +240,7 @@ def _registry_dir() -> Path:
     override = os.getenv("MESEN2_REGISTRY_DIR")
     if override:
         return Path(override).expanduser().resolve()
-    return (Path(__file__).resolve().parents[2] / ".context" / "scratchpad" / "mesen2" / "instances").resolve()
+    return (Path(__file__).resolve().parents[3] / ".context" / "scratchpad" / "mesen2" / "instances").resolve()
 
 
 def _resolve_instance_socket_path(instance: str) -> str | None:
@@ -1440,7 +1440,7 @@ def main():
             print(f"Health: {'OK' if info.get('ok') else 'FAIL'} (Latency: {info.get('latency_ms')}ms)")
             if not rom_loaded:
                 print("ROM: not loaded (load screen)")
-                print("Hint: python3 Scripts/mesen2_client.py rom-load <path-to-rom>")
+                print("Hint: python3 Scripts/Mesen2/mesen2_client.py rom-load <path-to-rom>")
             else:
                 print(f"ROM: {rom_info.get('filename')} (crc32={rom_info.get('crc32')})")
                 print(f"Emulator: {'Paused' if run_state.get('paused') else 'Running'} (Frame: {run_state.get('frame')})")
@@ -1473,7 +1473,7 @@ def main():
                 print(f"Error: {info.get('error')}")
             if not rom_loaded:
                 print("ROM: not loaded (load screen)")
-                print("Hint: python3 Scripts/mesen2_client.py rom-load <path-to-rom>")
+                print("Hint: python3 Scripts/Mesen2/mesen2_client.py rom-load <path-to-rom>")
             else:
                 print(f"ROM: {rom_info.get('filename')} (crc32={rom_info.get('crc32')})")
         if not info.get("ok"):

--- a/Scripts/Mesen2/mesen2_client_lib/tests/test_relocated_paths.py
+++ b/Scripts/Mesen2/mesen2_client_lib/tests/test_relocated_paths.py
@@ -1,0 +1,15 @@
+import mesen2_registry
+
+from mesen2_client_lib import bridge, cli
+from mesen2_client_lib.paths import REPO_ROOT
+
+
+def test_registry_defaults_share_repository_root(monkeypatch):
+    monkeypatch.delenv("MESEN2_REGISTRY_DIR", raising=False)
+    expected = (
+        REPO_ROOT / ".context" / "scratchpad" / "mesen2" / "instances"
+    ).resolve()
+
+    assert mesen2_registry._registry_dir() == expected
+    assert cli._registry_dir() == expected
+    assert bridge._registry_dir() == expected

--- a/Scripts/Mesen2/mesen2_launch_instance.sh
+++ b/Scripts/Mesen2/mesen2_launch_instance.sh
@@ -6,7 +6,7 @@ usage() {
 Launch an isolated Mesen2 OOS instance (safe for multi-agent work).
 
 USAGE:
-  Scripts/mesen2_launch_instance.sh [options]
+  Scripts/Mesen2/mesen2_launch_instance.sh [options]
 
 OPTIONS:
   --instance NAME        Instance name (default: <source>-<owner>)
@@ -42,7 +42,7 @@ EOF
 }
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 INSTANCE=""
 INSTANCE_SET=0
@@ -487,7 +487,7 @@ if [[ "${REUSE}" -eq 0 ]]; then
 fi
 
 if [[ "${REGISTER}" -eq 1 ]]; then
-  registry="${ROOT_DIR}/Scripts/mesen2_registry.py"
+  registry="${ROOT_DIR}/Scripts/Mesen2/mesen2_registry.py"
   if [[ -f "${registry}" ]]; then
     # wait briefly for socket
     for _ in {1..40}; do
@@ -516,4 +516,4 @@ echo "  export MESEN2_INSTANCE=\"${MESEN2_INSTANCE}\""
 echo "  export MESEN2_INSTANCE_GUID=\"${MESEN2_INSTANCE_GUID}\""
 echo ""
 echo "Verify:"
-echo "  python3 ${ROOT_DIR}/Scripts/mesen2_client.py --socket \"${MESEN2_SOCKET_PATH}\" health"
+echo "  python3 ${ROOT_DIR}/Scripts/Mesen2/mesen2_client.py --socket \"${MESEN2_SOCKET_PATH}\" health"

--- a/Scripts/Mesen2/mesen2_registry.py
+++ b/Scripts/Mesen2/mesen2_registry.py
@@ -15,9 +15,9 @@ from pathlib import Path
 from typing import Any
 
 SCRIPT_DIR = Path(__file__).resolve().parent
-REPO_ROOT = SCRIPT_DIR.parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
 
-# Allow imports from Scripts/mesen2_client_lib
+# Allow imports from Scripts/Mesen2/mesen2_client_lib
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 

--- a/Scripts/Mesen2/mesen2_sanity_check.sh
+++ b/Scripts/Mesen2/mesen2_sanity_check.sh
@@ -18,10 +18,10 @@ usage() {
 Mesen2 sanity check
 
 USAGE:
-  Scripts/mesen2_sanity_check.sh [options]
+  Scripts/Mesen2/mesen2_sanity_check.sh [options]
 
 OPTIONS:
-  --root <dir>       Oracle-of-Secrets repo root (default: script parent)
+  --root <dir>       Oracle-of-Secrets repo root (default: repository root)
   --instance <name>  Registry instance name to resolve socket
   --owner <name>     Owner label (optional, for logging)
   --rom <path>       Expected ROM path (optional)
@@ -93,11 +93,11 @@ done
 
 if [[ -z "$ROOT_DIR" ]]; then
   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+  ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 fi
 
 if [[ -z "$REGISTRY_SCRIPT" ]]; then
-  REGISTRY_SCRIPT="${ROOT_DIR}/Scripts/mesen2_registry.py"
+  REGISTRY_SCRIPT="${ROOT_DIR}/Scripts/Mesen2/mesen2_registry.py"
 fi
 
 if [[ $CHECK_REPO -eq 1 ]]; then
@@ -209,9 +209,9 @@ if [[ $rom_failed -ne 0 && $STRICT -eq 1 ]]; then
 fi
 
 log "State check..."
-python3 "$ROOT_DIR/Scripts/mesen2_client.py" state --json >/dev/null
+python3 "$ROOT_DIR/Scripts/Mesen2/mesen2_client.py" state --json >/dev/null
 
 log "Input check..."
-python3 "$ROOT_DIR/Scripts/mesen2_client.py" press RIGHT --frames 1 >/dev/null
+python3 "$ROOT_DIR/Scripts/Mesen2/mesen2_client.py" press RIGHT --frames 1 >/dev/null
 
 log "Sanity check OK."

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -5,13 +5,13 @@ This repo has accumulated scripts over time. The goal is to keep a small “gold
 ## Golden Path
 - Quick build + reload: `Scripts/oos-quick.sh`
 - Quick build + reload + validate: `Scripts/oos-verify.sh`
-- Named debug sessions: `Scripts/oos-session.sh`
-- Metadata popup control panel: `Scripts/oos_state_popup.py`
+- Named debug sessions: `Scripts/Build/oos-session.sh`
+- Metadata popup control panel: `Scripts/Debug/oos_state_popup.py`
 - Build loop: `Scripts/dev_loop.sh`
 - Build compatibility wrapper: `./build.sh`
 - Build ROM directly: `Scripts/build_rom.sh`
-- Debug client (socket API): `Scripts/mesen2_client.py`
-- Launch isolated Mesen2 instance: `Scripts/mesen2_launch_instance.sh`
+- Debug client (socket API): `Scripts/Mesen2/mesen2_client.py`
+- Launch isolated Mesen2 instance: `Scripts/Mesen2/mesen2_launch_instance.sh`
 - Run manifest-based tests: `Scripts/Validate/run_regression_tests.sh`
 - Verify ROM overlap: `Scripts/check_zscream_overlap.py`
 - Package a beta patch: `Scripts/beta_patch.sh`
@@ -35,12 +35,12 @@ This repo has accumulated scripts over time. The goal is to keep a small “gold
 ## Automation (Experimental / WIP)
 - `Scripts/campaign/` (agentic automation, autonomous debugging)
 
-If a doc references a script that does not exist (example: `mesen_cli.sh`), prefer the socket client (`Scripts/mesen2_client.py`) instead.
+If a doc references a script that does not exist (example: `mesen_cli.sh`), prefer the socket client (`Scripts/Mesen2/mesen2_client.py`) instead.
 
 ## Save-State Safety Defaults
 - `mesen2_launch_instance.sh` does **not** seed project slot states by default.
 - Opt-in legacy seeding only with `--seed-project-states`.
 - `oos-session.sh` loads task seeds from `Docs/Debugging/Testing/trusted_state_seeds.json` and requires `canon + human-captured` states.
 - Use `Scripts/set_trusted_state_seed.py <task> <state_id>` to map trusted library states to session tasks.
-- Use `Scripts/oos_state_popup.py --instance <name> [--font-size 18] [--theme dark] [--layout compact]` for integrated metadata capture, macros, shortcuts, and custom test actions.
+- Use `Scripts/Debug/oos_state_popup.py --instance <name> [--font-size 18] [--theme dark] [--layout compact]` for integrated metadata capture, macros, shortcuts, and custom test actions.
 - Macro buttons/shortcuts are loaded from `Docs/Debugging/Testing/oos_ui_macros.json` so workflows can be edited without Python changes.


### PR DESCRIPTION
## Summary
- resolve the Oracle repository root from `Scripts/Mesen2` instead of the `Scripts` directory
- update launcher, registry, client, and sanity-check references to relocated `Scripts/Mesen2/...` paths
- make the registry script, CLI, and bridge share `<repo>/.context/scratchpad/mesen2/instances` by default
- repair the Runbook-advertised `Scripts/Build/oos-session.sh` root, launcher path, and help examples
- refresh the directly related Mesen/session entries in `Scripts/README.md`
- add a focused regression test for the shared registry-root contract

## Verification
- `bash -n Scripts/Mesen2/mesen2_launch_instance.sh Scripts/Mesen2/mesen2_sanity_check.sh Scripts/Build/oos-session.sh`
- `python3 -m py_compile` on the modified registry, CLI, bridge, and path-contract test
- focused registry/instance tests: `4 passed in 0.04s`
- launcher, sanity-check, session, Python client, and registry `--help` from outside the repository
- repository-root and shared registry-directory assertions for registry/CLI/bridge
- no-emulator fixture exercise of `Scripts/Build/oos-session.sh free`
- launcher `--reuse --no-register` path/quoting exercise from outside the repository
- no legacy `Scripts/mesen2_*` paths in the executable golden-path files
- `git diff --check`

No emulator was started, attached to, or stopped.
