### PR TITLE
Repair Oracle ROM Tests workflow

### DIFF
--- a/.github/workflows/test-rom.yml
+++ b/.github/workflows/test-rom.yml
@@ -2,24 +2,25 @@ name: ROM Tests
 
 on:
   push:
-    branches: [main, develop]
+    branches: [master, develop]
     paths:
       - '**/*.asm'
       - '**/*.lua'
-      - 'scripts/**'
+      - 'Scripts/**'
       - '.github/workflows/test-rom.yml'
   pull_request:
-    branches: [main]
+    branches: [master]
     paths:
       - '**/*.asm'
       - '**/*.lua'
-      - 'scripts/**'
+      - 'Scripts/**'
+      - '.github/workflows/test-rom.yml'
   workflow_dispatch:
     inputs:
       run_emulator_tests:
         description: 'Run emulator tests (requires self-hosted runner with ROM)'
         required: false
-        default: 'false'
+        default: false
         type: boolean
 
 jobs:
@@ -35,12 +36,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Download Asar
+      - name: Build Asar
         run: |
-          # Download Asar assembler
-          wget -q https://github.com/RPGHacker/asar/releases/download/v1.91/asar191.zip
-          unzip -q asar191.zip -d asar
-          chmod +x asar/asar
+          # The v1.91 release archive contains only asar.exe, so build the
+          # Linux CLI from the exact v1.91 source commit.
+          ASAR_COMMIT=6a6dbdaed8cb773e583052ce4f66375bd896c3a1
+          wget -q "https://github.com/RPGHacker/asar/archive/${ASAR_COMMIT}.tar.gz" -O asar-src.tar.gz
+          mkdir asar-src
+          tar -xzf asar-src.tar.gz --strip-components=1 -C asar-src
+          cmake -S asar-src/src -B asar-build -DCMAKE_BUILD_TYPE=Release
+          cmake --build asar-build --config Release --target asar-standalone --parallel 2
+          mkdir -p asar
+          install -m 755 asar-build/asar/bin/asar asar/asar
+          ./asar/asar --version
 
       - name: Check ASM Syntax
         run: |
@@ -48,14 +56,15 @@ jobs:
           # This only validates syntax, not actual assembly output
           dd if=/dev/zero of=test.sfc bs=1024 count=2048 2>/dev/null
 
-          # Run Asar in check mode (--no-title-check allows headerless)
-          ./asar/asar --no-title-check Oracle_main.asm test.sfc 2>&1 | tee asar_output.txt
+          # Seed the source bytes inspected by guarded patches and the message
+          # bank terminator scanned at assembly time.
+          printf '\x73\x80\x39' | dd of=test.sfc bs=1 seek=$((0xE9E6)) conv=notrunc 2>/dev/null
+          printf '\x7A\x80\x38' | dd of=test.sfc bs=1 seek=$((0xE9F5)) conv=notrunc 2>/dev/null
+          printf '\x7F' | dd of=test.sfc bs=1 seek=$((0x773FF)) conv=notrunc 2>/dev/null
 
-          # Check for errors
-          if grep -q "error" asar_output.txt; then
-            echo "::error::ASM syntax errors found"
-            exit 1
-          fi
+          # Run Asar against the synthetic headerless ROM.
+          set -o pipefail
+          ./asar/asar --no-title-check Oracle_main.asm test.sfc 2>&1 | tee asar_output.txt
 
           echo "ASM syntax check passed"
 
@@ -78,13 +87,13 @@ jobs:
         run: |
           # Check all Lua scripts for syntax errors
           errors=0
-          for file in scripts/*.lua; do
+          while IFS= read -r -d '' file; do
             echo "Checking $file..."
-            if ! lua5.4 -p "$file" 2>&1; then
+            if ! luac5.4 -p "$file" 2>&1; then
               echo "::error file=$file::Syntax error in $file"
               errors=$((errors + 1))
             fi
-          done
+          done < <(find Scripts/Lua -type f -name '*.lua' -print0)
 
           if [ $errors -gt 0 ]; then
             echo "::error::Found $errors Lua syntax errors"
@@ -103,7 +112,7 @@ jobs:
   emulator-tests:
     name: Emulator Tests
     runs-on: self-hosted
-    if: github.event.inputs.run_emulator_tests == 'true' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && inputs.run_emulator_tests
     needs: [asm-check, lua-check]
 
     steps:
@@ -114,11 +123,12 @@ jobs:
         id: check-rom
         run: |
           if [ -f ~/roms/alttp/oos168.sfc ]; then
-            echo "rom_available=true" >> $GITHUB_OUTPUT
+            echo "rom_available=true" >> "$GITHUB_OUTPUT"
             echo "Base ROM found"
           else
-            echo "rom_available=false" >> $GITHUB_OUTPUT
-            echo "::warning::Base ROM not found at ~/roms/alttp/oos168.sfc"
+            echo "rom_available=false" >> "$GITHUB_OUTPUT"
+            echo "::error::Base ROM not found at ~/roms/alttp/oos168.sfc"
+            exit 1
           fi
 
       - name: Build Patched ROM
@@ -128,31 +138,17 @@ jobs:
           cp ~/roms/alttp/oos168.sfc Roms/
 
           # Build patched ROM
-          ASAR_BIN="${ASAR_BIN:-asar}" ./scripts/build_rom.sh 168
+          ASAR_BIN="${ASAR_BIN:-asar}" ./Scripts/Build/build_rom.sh 168
 
       - name: Run Boot Test
         if: steps.check-rom.outputs.rom_available == 'true'
         run: |
           # Run boot verification test
           Mesen --testRunner --timeout=30 \
-            scripts/verify_boot.lua \
+            Scripts/Lua/verify_boot.lua \
             Roms/oos168x.sfc
 
           echo "Boot test passed"
-        continue-on-error: true
-
-      - name: Run Water Gate Test
-        if: steps.check-rom.outputs.rom_available == 'true'
-        run: |
-          # Run water gate persistence test
-          # Note: This test requires manual navigation to room 0x27
-          # In automated mode, it will timeout waiting for the room
-          Mesen --testRunner --timeout=120 \
-            scripts/verify_water_gate.lua \
-            Roms/oos168x.sfc
-
-          echo "Water gate test completed"
-        continue-on-error: true
 
       - name: Upload Test Logs
         if: always() && steps.check-rom.outputs.rom_available == 'true'
@@ -176,20 +172,20 @@ jobs:
     steps:
       - name: Check Results
         run: |
-          echo "## Test Results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## Test Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
 
           if [ "${{ needs.asm-check.result }}" == "success" ]; then
-            echo "- ASM Syntax: :white_check_mark: Passed" >> $GITHUB_STEP_SUMMARY
+            echo "- ASM Syntax: :white_check_mark: Passed" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "- ASM Syntax: :x: Failed" >> $GITHUB_STEP_SUMMARY
+            echo "- ASM Syntax: :x: Failed" >> "$GITHUB_STEP_SUMMARY"
           fi
 
           if [ "${{ needs.lua-check.result }}" == "success" ]; then
-            echo "- Lua Syntax: :white_check_mark: Passed" >> $GITHUB_STEP_SUMMARY
+            echo "- Lua Syntax: :white_check_mark: Passed" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "- Lua Syntax: :x: Failed" >> $GITHUB_STEP_SUMMARY
+            echo "- Lua Syntax: :x: Failed" >> "$GITHUB_STEP_SUMMARY"
           fi
 
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "_Emulator tests require self-hosted runner with ROM._" >> $GITHUB_STEP_SUMMARY
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "_Emulator tests require self-hosted runner with ROM._" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- retarget the ROM Tests workflow from the nonexistent `main` branch to `master` and use case-exact `Scripts/**` paths
- build Asar 1.91 from its pinned source commit, seed the guarded synthetic ROM bytes, and propagate assembly failures through `pipefail`
- validate all current Lua scripts recursively with `luac5.4`, and use the canonical ROM build and boot-script paths
- make emulator tests an explicit manual opt-in that fails when its base ROM or boot test is unavailable
- remove the stale water-gate step whose referenced verifier was deleted and has no current headless replacement

## Root cause

The workflow had not followed the repository's branch and `Scripts/` reorganization. Its Asar release archive did not provide a Linux CLI, its assembly pipeline could hide failures, and its emulator condition ran on every manual dispatch while missing runtime files could be treated as success.

## Verification

- `actionlint .github/workflows/test-rom.yml`
- built pinned Asar source commit `6a6dbdaed8cb773e583052ce4f66375bd896c3a1` (Asar 1.91)
- seeded synthetic assembly completed with exit code 0; output size 2,150,714 bytes, SHA-256 `e7ff81456a3d419003ebb094280ab82e0316177d4dc1cb3fb1302f5d0d488c7e`
- recursively parsed 7 Lua files with `luac5.4`: 0 errors
- `git diff --check HEAD^ HEAD`

## Remaining runtime evidence

The opt-in self-hosted Mesen test has not been run in this branch. Automated water-gate coverage remains absent until a supported headless verifier is added.
