### PR TITLE
Restore fail-closed dungeon save metadata

### DIFF
--- a/Core/message.asm
+++ b/Core/message.asm
@@ -18,7 +18,7 @@ endwhile
 ; So the end of the data bank is not as easily searchable.
 org $0EEE75 : db $80
 
-org !addr+1 : db $80
+org !addr+1 : assert ((!addr+1)>>16) == $0E, "Expanded message terminator left bank $0E" : db $80 ; @manifest-org-bank=$0E
 
 org $0ED436
   JML MessageExpand

--- a/Core/sprite_macros.asm
+++ b/Core/sprite_macros.asm
@@ -4,40 +4,40 @@ macro Set_Sprite_Properties(SprPrep, SprMain)
   assert !SPRID <= $F2, "Sprite ID !SPRID exceeds vanilla table limit ($F2 max). Use an ID in range $00-$F2."
 
   pushpc ; Save writing Position for the sprite
-  org $0DB080+!SPRID ; Oam Harmless ($0E40)
+  org $0DB080+!SPRID ; Oam Harmless ($0E40) ; @manifest-org-bank=$0D
   db ((!Harmless<<7)|(!HVelocity<<6)|!NbrTiles)
 
-  org $0DB173+!SPRID ; Sprite HP ($0E50)
+  org $0DB173+!SPRID ; Sprite HP ($0E50) ; @manifest-org-bank=$0D
   db !Health
 
-  org $0DB266+!SPRID ; Sprite Damage ($0CD2)
+  org $0DB266+!SPRID ; Sprite Damage ($0CD2) ; @manifest-org-bank=$0D
   db !Damage
 
-  org $0DB359+!SPRID ; Sprite Data ($0E60 / $0F50)
+  org $0DB359+!SPRID ; Sprite Data ($0E60 / $0F50) ; @manifest-org-bank=$0D
   db ((!DeathAnimation<<7)|(!ImperviousAll<<6)|(!SmallShadow<<5)|(!Shadow<<4)|(!Palette<<1))
 
-  org $0DB44C+!SPRID ; Sprite Hitbox ($0F60)
+  org $0DB44C+!SPRID ; Sprite Hitbox ($0F60) ; @manifest-org-bank=$0D
   db ((!CollisionLayer<<7)|(!Statis<<6)|(!Persist<<5)|(!Hitbox))
 
-  org $0DB53F+!SPRID ; Sprite Fall ($0B6B)
+  org $0DB53F+!SPRID ; Sprite Fall ($0B6B) ; @manifest-org-bank=$0D
   db ((!DeflectArrow<<3)|(!Boss<<1)|!CanFall)
 
-  org $0DB632+!SPRID ; Sprite Prize ($0BE0)
+  org $0DB632+!SPRID ; Sprite Prize ($0BE0) ; @manifest-org-bank=$0D
   db ((!Interaction<<7)|(!WaterSprite<<6)|(!Blockable<<5)|(!Sound<<4)|!Prize)
 
-  org $0DB725+!SPRID ; Sprite ($0CAA)
+  org $0DB725+!SPRID ; Sprite ($0CAA) ; @manifest-org-bank=$0D
   db ($40|(!Statue<<5)|(!DeflectProjectiles<<4)|(!ImpervSwordHammer<<2)|(!ImperviousArrow<<1))
 
-  org $069283+(!SPRID*2) ; Vanilla Sprite Main Pointer
+  org $069283+(!SPRID*2) ; Vanilla Sprite Main Pointer ; @manifest-org-bank=$06
   dw NewMainSprFunction
 
-  org $06865B+(!SPRID*2) ; Vanilla Sprite Prep Pointer
+  org $06865B+(!SPRID*2) ; Vanilla Sprite Prep Pointer ; @manifest-org-bank=$06
   dw NewSprPrepFunction
 
-  org NewSprRoutinesLong+(!SPRID*3) ; New Long Sprite Pointer
+  org NewSprRoutinesLong+(!SPRID*3) : assert ((NewSprRoutinesLong+(!SPRID*3))>>16) == $30, "Sprite main pointer left bank $30" ; New Long Sprite Pointer ; @manifest-org-bank=$30
   dl <SprMain>
 
-  org NewSprPrepRoutinesLong+(!SPRID*3) ; New Long Sprite Pointer
+  org NewSprPrepRoutinesLong+(!SPRID*3) : assert ((NewSprPrepRoutinesLong+(!SPRID*3))>>16) == $30, "Sprite prep pointer left bank $30" ; New Long Sprite Pointer ; @manifest-org-bank=$30
   dl <SprPrep>
   pullpc ; Get back the writing position for the sprite
 }

--- a/Oracle-of-Secrets.yaze
+++ b/Oracle-of-Secrets.yaze
@@ -31,7 +31,7 @@ additional_roms=
 
 [rom]
 role=dev
-expected_hash=eaf2ce3d28afa5375adf9c754534a7a98bf06822
+expected_hash=58c9fadc6228d3d78d6baa7b7cc1c31cf57ed196
 write_policy=block
 
 [feature_flags]

--- a/Scripts/Generate/generate_hack_manifest.py
+++ b/Scripts/Generate/generate_hack_manifest.py
@@ -47,15 +47,13 @@ from typing import Iterable, Optional
 
 # Import the existing hooks scanner infrastructure
 from generate_hooks_json import (
-    ELSE_DIRECTIVE_RE,
-    ENDIF_DIRECTIVE_RE,
-    IF_DIRECTIVE_RE,
-    _eval_condition,
-    filter_active_asm_sources,
+    DEFINE_ANY_ASSIGN_RE,
+    scan_org_directives,
     scan_hooks,
     _load_global_defines,
-    _parse_define_assignment,
+    _iter_active_lines,
     HookEntry,
+    OrgDirective,
 )
 
 # ---------------------------------------------------------------------------
@@ -117,10 +115,58 @@ EXPANDED_MESSAGE_DATA_START = 0x2F8026
 EXPANDED_MESSAGE_DATA_END = 0x2FFDFF
 MINECART_TRACK_SOURCE = Path("Sprites/Objects/data/minecart_tracks.asm")
 DUNGEON_ROOM_COUNT = 296
+OBJECT_TABLE_POINTER_OPERAND_PC = 0x874C
+SPRITE_TABLE_POINTER_OPERAND_PC = 0x4C298
+POT_POINTER_TABLE_PC = 0xDB69
 ROOM_HEADER_POINTER_PC = 0xB5DD
 ROOM_HEADER_BANK_PC = 0xB5E7
 ROOM_HEADER_SIZE = 14
 DUNGEON_MESSAGE_IDS_PC = 0x3F61D
+SPRITE_DATA_END_PC = 0x4EC9F
+POT_DATA_START_PC = 0xDDE7
+POT_DATA_END_PC = 0xE6B2
+CUSTOM_COLLISION_POINTER_TABLE_PC = 0x128090
+CUSTOM_COLLISION_DATA_START_PC = 0x128450
+CUSTOM_COLLISION_DATA_END_PC = 0x12E000
+CUSTOM_COLLISION_MAP_WIDTH = 64
+CUSTOM_COLLISION_MAP_HEIGHT = 64
+CUSTOM_COLLISION_MAP_TILES = (
+    CUSTOM_COLLISION_MAP_WIDTH * CUSTOM_COLLISION_MAP_HEIGHT
+)
+
+OBJECT_DATA_REGIONS_PC = (
+    (0x50000, 0x53730),
+    (0xF878A, 0x100000),
+    (0x1EB90, 0x20000),
+    (0x138000, 0x140000),
+    (0x148000, 0x150000),
+)
+OBJECT_ALLOCATION_REGIONS_PC = ((0x148000, 0x150000),)
+CANONICAL_LOROM_ROM_END_PC = 0x3F0000
+
+AUDITED_UNRESOLVED_ORG_CONTRACTS = {
+    ("Core/message.asm", "!addr+1", 0x0E),
+    ("Core/sprite_macros.asm", "$0DB080+!SPRID", 0x0D),
+    ("Core/sprite_macros.asm", "$0DB173+!SPRID", 0x0D),
+    ("Core/sprite_macros.asm", "$0DB266+!SPRID", 0x0D),
+    ("Core/sprite_macros.asm", "$0DB359+!SPRID", 0x0D),
+    ("Core/sprite_macros.asm", "$0DB44C+!SPRID", 0x0D),
+    ("Core/sprite_macros.asm", "$0DB53F+!SPRID", 0x0D),
+    ("Core/sprite_macros.asm", "$0DB632+!SPRID", 0x0D),
+    ("Core/sprite_macros.asm", "$0DB725+!SPRID", 0x0D),
+    ("Core/sprite_macros.asm", "$069283+(!SPRID*2)", 0x06),
+    ("Core/sprite_macros.asm", "$06865B+(!SPRID*2)", 0x06),
+    (
+        "Core/sprite_macros.asm",
+        "NewSprRoutinesLong+(!SPRID*3)",
+        0x30,
+    ),
+    (
+        "Core/sprite_macros.asm",
+        "NewSprPrepRoutinesLong+(!SPRID*3)",
+        0x30,
+    ),
+}
 
 
 class ManifestGenerationError(RuntimeError):
@@ -141,62 +187,10 @@ def _iter_active_incsrcs(
     global_defines: dict[str, int],
 ) -> Iterable[tuple[int, str]]:
     """Yield literal includes whose enclosing Asar condition is active."""
-    defines = dict(global_defines)
-    active = True
-    stack: list[dict[str, object]] = []
-
-    for line_number, line in enumerate(lines, start=1):
-        directive = line.split(";", 1)[0].strip()
-        match = IF_DIRECTIVE_RE.match(directive)
-        if match:
-            kind = match.group(1).lower()
-            condition = _eval_condition(match.group(2).strip(), defines)
-            condition_active = (
-                bool(condition) if condition is not None else True
-            )
-            if kind == "if":
-                parent_active = active
-                branch_taken = parent_active and condition_active
-                active = branch_taken
-                stack.append({
-                    "parent_active": parent_active,
-                    "branch_taken": branch_taken,
-                })
-            elif stack:
-                frame = stack[-1]
-                parent_active = bool(frame["parent_active"])
-                branch_taken = bool(frame["branch_taken"])
-                active = (
-                    parent_active
-                    and not branch_taken
-                    and condition_active
-                )
-                frame["branch_taken"] = branch_taken or active
-            continue
-        if ELSE_DIRECTIVE_RE.match(directive):
-            if stack:
-                frame = stack[-1]
-                parent_active = bool(frame["parent_active"])
-                branch_taken = bool(frame["branch_taken"])
-                active = parent_active and not branch_taken
-                frame["branch_taken"] = True
-            continue
-        if ENDIF_DIRECTIVE_RE.match(directive):
-            if stack:
-                frame = stack.pop()
-                active = bool(frame["parent_active"])
-            continue
-        if not active:
-            continue
-
-        parsed_define = _parse_define_assignment(line)
-        if parsed_define is not None:
-            name, value = parsed_define
-            defines[name] = value
-
+    for line_index, line, _ in _iter_active_lines(lines, global_defines):
         include_text = _parse_incsrc(line)
         if include_text is not None:
-            yield line_number, include_text
+            yield line_index + 1, include_text
 
 
 def _is_case_exact_file(candidate: Path, root: Path) -> bool:
@@ -228,9 +222,10 @@ def collect_reachable_asm_sources(
     """Collect the transitive literal `incsrc` graph for the build entry.
 
     Asar sources in this repository use both paths relative to the including
-    file and repo-root-relative paths. Follow only active conditional edges,
-    gate disabled module roots before traversal, and fail closed if an active
-    reachable include cannot be resolved.
+    file and repo-root-relative paths. Follow every feasible conditional edge,
+    treat literal includes as authoritative regardless of directory name, and
+    fail closed when a reachable include or cross-file global-define state
+    cannot be resolved safely.
     """
     resolved_root = root.resolve()
     entry = entry_point if entry_point.is_absolute() else resolved_root / entry_point
@@ -289,11 +284,34 @@ def collect_reachable_asm_sources(
                     f"{rel}:{line_number}: incsrc escapes repo root: "
                     f"{include_text!r}"
                 )
-            if not filter_active_asm_sources(
-                resolved_root, [included], active_defines
-            ):
-                continue
             pending.append(included)
+
+    canonical_define_sources = {
+        "Util/macros.asm",
+        "Config/module_flags.asm",
+        "Config/feature_flags.asm",
+    }
+    for asm_path in sorted(reachable):
+        rel = asm_path.relative_to(resolved_root).as_posix()
+        if rel in canonical_define_sources:
+            continue
+        try:
+            lines = asm_path.read_text(
+                encoding="utf-8", errors="ignore"
+            ).splitlines()
+        except OSError as exc:
+            raise ManifestGenerationError(
+                f"Unable to validate reachable ASM source {asm_path}: {exc}"
+            ) from exc
+        for line_index, line, _ in _iter_active_lines(lines, active_defines):
+            assignment = DEFINE_ANY_ASSIGN_RE.match(line.split(";", 1)[0])
+            if assignment and assignment.group(1) in active_defines:
+                raise ManifestGenerationError(
+                    f"{rel}:{line_index + 1}: reachable source reassigns "
+                    f"preloaded global define !{assignment.group(1)} outside "
+                    "the canonical define files; include-order state cannot "
+                    "be resolved safely"
+                )
 
     return sorted(reachable)
 
@@ -324,7 +342,7 @@ def scan_bank_ownership(
         if asm_paths is None
         else asm_paths
     )
-    source_paths = filter_active_asm_sources(root, candidate_paths)
+    source_paths = list(candidate_paths)
     for asm_path in source_paths:
         asm_path = asm_path.resolve()
         try:
@@ -542,9 +560,7 @@ def scan_room_tags(
         if asm_paths is None
         else asm_paths
     )
-    source_paths = filter_active_asm_sources(
-        root, candidate_paths, defines
-    )
+    source_paths = list(candidate_paths)
     for asm_path in source_paths:
         asm_path = asm_path.resolve()
         try:
@@ -772,12 +788,17 @@ def compute_protected_regions(hooks: list[HookEntry]) -> list[dict]:
     sorted_hooks = sorted(hooks, key=lambda hook: _snes_to_pc(hook.address))
     regions = []
     current_start = _snes_to_pc(sorted_hooks[0].address)
-    current_end = current_start + SIZE_ESTIMATE.get(sorted_hooks[0].kind, 4)
+    current_end = current_start + (
+        sorted_hooks[0].protected_size
+        or SIZE_ESTIMATE.get(sorted_hooks[0].kind, 4)
+    )
     current_hooks = [sorted_hooks[0]]
 
     for hook in sorted_hooks[1:]:
         hook_start = _snes_to_pc(hook.address)
-        hook_end = hook_start + SIZE_ESTIMATE.get(hook.kind, 4)
+        hook_end = hook_start + (
+            hook.protected_size or SIZE_ESTIMATE.get(hook.kind, 4)
+        )
 
         # Merge if within 16 bytes of the previous region (likely related)
         if hook_start <= current_end + 16:
@@ -818,10 +839,15 @@ def _canonical_lorom_address(address: int) -> int:
         raise ManifestGenerationError(
             f"SNES address 0x{address:X} is outside 24-bit address space"
         )
-    address &= 0x7FFFFF
-    if (address & 0xFFFF) < 0x8000:
-        address |= 0x8000
-    return address
+    canonical = address & 0x7FFFFF
+    bank = (canonical >> 16) & 0x7F
+    if bank in (0x7E, 0x7F):
+        raise ManifestGenerationError(
+            f"SNES address 0x{address:06X} points to WRAM or its FastROM mirror"
+        )
+    if (canonical & 0xFFFF) < 0x8000:
+        canonical |= 0x8000
+    return canonical
 
 
 def _snes_to_pc(address: int) -> int:
@@ -851,22 +877,28 @@ def _strict_lorom_to_pc(address: int, description: str) -> int:
         )
     bank = (address >> 16) & 0xFF
     offset = address & 0xFFFF
-    if bank in (0x7E, 0x7F):
+    if bank in (0x7E, 0x7F, 0xFE, 0xFF):
         raise ManifestGenerationError(
-            f"{description} 0x{address:06X} points to WRAM"
+            f"{description} 0x{address:06X} points to WRAM or its FastROM mirror"
         )
     if offset < 0x8000:
         raise ManifestGenerationError(
             f"{description} 0x{address:06X} is not a high-half LoROM pointer"
         )
-    return ((bank & 0x7F) << 15) | (offset & 0x7FFF)
+    pc_address = ((bank & 0x7F) << 15) | (offset & 0x7FFF)
+    if pc_address >= CANONICAL_LOROM_ROM_END_PC:
+        raise ManifestGenerationError(
+            f"{description} 0x{address:06X} maps into the WRAM-backed "
+            "LoROM PC window"
+        )
+    return pc_address
 
 
 def _pc_to_snes(address: int) -> int:
     """Convert an unheadered PC offset to a canonical LoROM address."""
-    if not 0 <= address < 0x400000:
+    if not 0 <= address < CANONICAL_LOROM_ROM_END_PC:
         raise ManifestGenerationError(
-            f"PC address 0x{address:X} is outside canonical LoROM"
+            f"PC address 0x{address:X} is outside canonical ROM-backed LoROM"
         )
     snes = (
         ((address << 1) & 0x7F0000)
@@ -898,6 +930,11 @@ def _read_u16(data: bytes, address: int, description: str) -> int:
     return data[address] | (data[address + 1] << 8)
 
 
+def _read_u8(data: bytes, address: int, description: str) -> int:
+    _require_rom_span(data, address, 1, description)
+    return data[address]
+
+
 def _read_u24(data: bytes, address: int, description: str) -> int:
     _require_rom_span(data, address, 3, description)
     return (
@@ -919,8 +956,478 @@ def _editor_range(start_pc: int, end_pc: int) -> dict[str, str]:
     }
 
 
+def _range_contains(outer: tuple[int, int], inner: tuple[int, int]) -> bool:
+    return outer[0] <= inner[0] and inner[1] <= outer[1]
+
+
+def _validate_regions(
+    data: bytes,
+    stream_name: str,
+    data_regions: tuple[tuple[int, int], ...],
+    allocation_regions: tuple[tuple[int, int], ...],
+) -> None:
+    if not data_regions or not allocation_regions:
+        raise ManifestGenerationError(
+            f"{stream_name} data/allocation regions must be non-empty"
+        )
+
+    sorted_data = sorted(data_regions)
+    for index, (start, end) in enumerate(sorted_data):
+        if start >= end:
+            raise ManifestGenerationError(
+                f"{stream_name} data region {index} is empty or reversed"
+            )
+        _require_rom_span(
+            data, start, end - start, f"{stream_name} data region {index}"
+        )
+        _pc_to_snes(start)
+        _pc_to_snes(end)
+        if index and start < sorted_data[index - 1][1]:
+            raise ManifestGenerationError(
+                f"{stream_name} data regions overlap at PC 0x{start:X}"
+            )
+
+    sorted_allocations = sorted(allocation_regions)
+    for index, allocation in enumerate(sorted_allocations):
+        start, end = allocation
+        if start >= end:
+            raise ManifestGenerationError(
+                f"{stream_name} allocation region {index} is empty or reversed"
+            )
+        if not any(_range_contains(region, allocation) for region in data_regions):
+            raise ManifestGenerationError(
+                f"{stream_name} allocation [0x{start:X}, 0x{end:X}) is not "
+                "contained in a data region"
+            )
+        if index and start < sorted_allocations[index - 1][1]:
+            raise ManifestGenerationError(
+                f"{stream_name} allocation regions overlap at PC 0x{start:X}"
+            )
+
+
+def _pointer_pc_in_regions(
+    pointer_pc: int, regions: tuple[tuple[int, int], ...]
+) -> bool:
+    return any(start <= pointer_pc < end for start, end in regions)
+
+
+def _validate_disjoint_named_ranges(
+    ranges: list[tuple[str, int, int]], description: str
+) -> None:
+    sorted_ranges = sorted(ranges, key=lambda item: (item[1], item[2]))
+    for previous, current in zip(sorted_ranges, sorted_ranges[1:]):
+        if current[1] < previous[2]:
+            raise ManifestGenerationError(
+                f"{description} overlap: {previous[0]} "
+                f"[0x{previous[1]:X}, 0x{previous[2]:X}) conflicts with "
+                f"{current[0]} [0x{current[1]:X}, 0x{current[2]:X})"
+            )
+
+
+def _dungeon_stream_parse_limit(
+    pointer_pc: int,
+    regions: tuple[tuple[int, int], ...],
+) -> int:
+    containing_end = next(
+        (end for start, end in regions if start <= pointer_pc < end),
+        None,
+    )
+    if containing_end is None:
+        raise ManifestGenerationError(
+            f"dungeon stream pointer PC 0x{pointer_pc:X} is outside its "
+            "declared data regions"
+        )
+    bank_end = ((pointer_pc // 0x8000) + 1) * 0x8000
+    return min(containing_end, bank_end)
+
+
+def _find_dungeon_stream_end(
+    data: bytes,
+    stream_name: str,
+    room_id: int,
+    start_pc: int,
+    limit_pc: int,
+) -> int:
+    """Return a format-valid stream's exclusive logical end."""
+
+    def require(size: int, description: str) -> None:
+        if size < 0 or cursor + size > limit_pc:
+            raise ManifestGenerationError(
+                f"{stream_name} stream for room 0x{room_id:03X} {description} "
+                f"before parse limit PC 0x{limit_pc:X}"
+            )
+        _require_rom_span(data, cursor, size, description)
+
+    cursor = start_pc
+    if stream_name == "objects":
+        require(2, "is missing its two-byte header")
+        cursor += 2
+        for list_id in range(2):
+            while True:
+                require(2, f"list {list_id} has no 0xFFFF terminator")
+                if data[cursor : cursor + 2] == b"\xFF\xFF":
+                    cursor += 2
+                    break
+                require(3, f"list {list_id} has a truncated record")
+                cursor += 3
+
+        in_doors = False
+        while True:
+            require(
+                2,
+                (
+                    "door list has no 0xFFFF terminator"
+                    if in_doors
+                    else "list 2 has no door marker or terminator"
+                ),
+            )
+            marker = data[cursor : cursor + 2]
+            if marker == b"\xFF\xFF":
+                return cursor + 2
+            if not in_doors and marker == b"\xF0\xFF":
+                cursor += 2
+                in_doors = True
+                continue
+            if in_doors:
+                cursor += 2
+            else:
+                require(3, "list 2 has a truncated record")
+                cursor += 3
+
+    if stream_name == "sprites":
+        require(1, "is missing its sort byte")
+        cursor += 1
+        while True:
+            require(1, "has no 0xFF terminator")
+            if data[cursor] == 0xFF:
+                return cursor + 1
+            require(3, "has a truncated record")
+            cursor += 3
+
+    if stream_name == "pot_items":
+        while True:
+            require(2, "has no 0xFFFF terminator")
+            if data[cursor : cursor + 2] == b"\xFF\xFF":
+                return cursor + 2
+            require(3, "has a truncated record")
+            cursor += 3
+
+    raise ManifestGenerationError(f"unsupported dungeon stream {stream_name}")
+
+
+def _derive_dungeon_stream_regions(data: bytes) -> dict:
+    object_table_snes = _read_u24(
+        data,
+        OBJECT_TABLE_POINTER_OPERAND_PC,
+        "object pointer-table operand",
+    )
+    object_table_pc = _strict_lorom_to_pc(
+        object_table_snes, "Object pointer-table operand"
+    )
+    object_table_size = DUNGEON_ROOM_COUNT * 3
+    _require_rom_span(data, object_table_pc, object_table_size, "object pointer table")
+    _validate_regions(
+        data,
+        "objects",
+        OBJECT_DATA_REGIONS_PC,
+        OBJECT_ALLOCATION_REGIONS_PC,
+    )
+    for room_id in range(DUNGEON_ROOM_COUNT):
+        object_pointer = _read_u24(
+            data,
+            object_table_pc + room_id * 3,
+            f"object pointer for room 0x{room_id:03X}",
+        )
+        object_data_pc = _strict_lorom_to_pc(
+            object_pointer, f"Object pointer for room 0x{room_id:03X}"
+        )
+        if not _pointer_pc_in_regions(object_data_pc, OBJECT_DATA_REGIONS_PC):
+            raise ManifestGenerationError(
+                f"object pointer for room 0x{room_id:03X} resolves to PC "
+                f"0x{object_data_pc:X}, outside declared object data regions"
+            )
+        _find_dungeon_stream_end(
+            data,
+            "objects",
+            room_id,
+            object_data_pc,
+            _dungeon_stream_parse_limit(
+                object_data_pc, OBJECT_DATA_REGIONS_PC
+            ),
+        )
+
+    sprite_table_low = _read_u16(
+        data,
+        SPRITE_TABLE_POINTER_OPERAND_PC,
+        "sprite pointer-table operand",
+    )
+    sprite_table_snes = 0x090000 | sprite_table_low
+    sprite_table_pc = _strict_lorom_to_pc(
+        sprite_table_snes, "Sprite pointer-table operand"
+    )
+    sprite_table_size = DUNGEON_ROOM_COUNT * 2
+    _require_rom_span(data, sprite_table_pc, sprite_table_size, "sprite pointer table")
+    sprite_pointers_pc: list[int] = []
+    for room_id in range(DUNGEON_ROOM_COUNT):
+        pointer_low = _read_u16(
+            data,
+            sprite_table_pc + room_id * 2,
+            f"sprite pointer for room 0x{room_id:03X}",
+        )
+        sprite_pointers_pc.append(
+            _strict_lorom_to_pc(
+                0x090000 | pointer_low,
+                f"Sprite pointer for room 0x{room_id:03X}",
+            )
+        )
+    sprite_data_start_pc = sprite_table_pc + sprite_table_size
+    minimum_sprite_pointer_pc = min(sprite_pointers_pc)
+    if minimum_sprite_pointer_pc < sprite_data_start_pc:
+        raise ManifestGenerationError(
+            f"minimum sprite pointer PC 0x{minimum_sprite_pointer_pc:X} "
+            f"precedes pointer-table end PC 0x{sprite_data_start_pc:X}"
+        )
+    sprite_regions = ((sprite_data_start_pc, SPRITE_DATA_END_PC),)
+    _validate_regions(data, "sprites", sprite_regions, sprite_regions)
+    for room_id, pointer_pc in enumerate(sprite_pointers_pc):
+        if not _pointer_pc_in_regions(pointer_pc, sprite_regions):
+            raise ManifestGenerationError(
+                f"sprite pointer for room 0x{room_id:03X} resolves to PC "
+                f"0x{pointer_pc:X}, outside sprite data region"
+            )
+        _find_dungeon_stream_end(
+            data,
+            "sprites",
+            room_id,
+            pointer_pc,
+            _dungeon_stream_parse_limit(pointer_pc, sprite_regions),
+        )
+
+    pot_table_size = DUNGEON_ROOM_COUNT * 2
+    _require_rom_span(
+        data, POT_POINTER_TABLE_PC, pot_table_size, "pot-item pointer table"
+    )
+    pot_pointers_pc: list[int] = []
+    for room_id in range(DUNGEON_ROOM_COUNT):
+        pointer_low = _read_u16(
+            data,
+            POT_POINTER_TABLE_PC + room_id * 2,
+            f"pot-item pointer for room 0x{room_id:03X}",
+        )
+        if pointer_low < 0x8000:
+            raise ManifestGenerationError(
+                f"pot-item pointer for room 0x{room_id:03X} is unmapped "
+                f"bank-$01 value 0x{pointer_low:04X}"
+            )
+        pot_pointers_pc.append(
+            _strict_lorom_to_pc(
+                0x010000 | pointer_low,
+                f"Pot-item pointer for room 0x{room_id:03X}",
+            )
+        )
+    pot_regions = ((POT_DATA_START_PC, POT_DATA_END_PC),)
+    _validate_regions(data, "pot_items", pot_regions, pot_regions)
+    for room_id, pointer_pc in enumerate(pot_pointers_pc):
+        if not _pointer_pc_in_regions(pointer_pc, pot_regions):
+            raise ManifestGenerationError(
+                f"pot-item pointer for room 0x{room_id:03X} resolves to PC "
+                f"0x{pointer_pc:X}, outside pot-item data region"
+            )
+        _find_dungeon_stream_end(
+            data,
+            "pot_items",
+            room_id,
+            pointer_pc,
+            _dungeon_stream_parse_limit(pointer_pc, pot_regions),
+        )
+
+    stream_data_regions = {
+        "objects": OBJECT_DATA_REGIONS_PC,
+        "sprites": sprite_regions,
+        "pot_items": pot_regions,
+    }
+    pointer_tables = {
+        "objects": (object_table_pc, object_table_pc + object_table_size),
+        "sprites": (sprite_table_pc, sprite_table_pc + sprite_table_size),
+        "pot_items": (
+            POT_POINTER_TABLE_PC,
+            POT_POINTER_TABLE_PC + pot_table_size,
+        ),
+    }
+    occupied_ranges = [
+        (f"{name}.pointer_table", start, end)
+        for name, (start, end) in pointer_tables.items()
+    ]
+    occupied_ranges.extend(
+        (f"{name}.data_regions[{index}]", start, end)
+        for name, ranges in stream_data_regions.items()
+        for index, (start, end) in enumerate(ranges)
+    )
+    occupied_ranges.extend(
+        (
+            (
+                "objects.pointer_source",
+                OBJECT_TABLE_POINTER_OPERAND_PC,
+                OBJECT_TABLE_POINTER_OPERAND_PC + 3,
+            ),
+            (
+                "sprites.pointer_source",
+                SPRITE_TABLE_POINTER_OPERAND_PC,
+                SPRITE_TABLE_POINTER_OPERAND_PC + 2,
+            ),
+            (
+                "objects.door_pointer_table",
+                0xF83C0,
+                0xF83C0 + DUNGEON_ROOM_COUNT * 3,
+            ),
+        )
+    )
+    _validate_disjoint_named_ranges(
+        occupied_ranges, "dungeon stream pointer/data ranges"
+    )
+    _validate_disjoint_named_ranges(
+        [
+            (
+                "objects.allocation_regions[0]",
+                *OBJECT_ALLOCATION_REGIONS_PC[0],
+            ),
+            ("sprites.allocation_regions[0]", *sprite_regions[0]),
+            ("pot_items.allocation_regions[0]", *pot_regions[0]),
+        ],
+        "dungeon stream allocation ranges",
+    )
+
+    return {
+        "objects": {
+            "pointer_table": f"0x{_pc_to_snes(object_table_pc):06X}",
+            "pointer_count": DUNGEON_ROOM_COUNT,
+            "pointer_encoding": "long24",
+            "strategy": "copy_on_write",
+            "data_regions": [
+                _editor_range(start, end) for start, end in OBJECT_DATA_REGIONS_PC
+            ],
+            "allocation_regions": [
+                _editor_range(start, end) for start, end in OBJECT_ALLOCATION_REGIONS_PC
+            ],
+        },
+        "sprites": {
+            "pointer_table": f"0x{_pc_to_snes(sprite_table_pc):06X}",
+            "pointer_count": DUNGEON_ROOM_COUNT,
+            "pointer_encoding": "bank16",
+            "pointer_bank": "0x09",
+            "strategy": "copy_on_write",
+            "data_regions": [
+                _editor_range(start, end) for start, end in sprite_regions
+            ],
+            "allocation_regions": [
+                _editor_range(start, end) for start, end in sprite_regions
+            ],
+        },
+        "pot_items": {
+            "pointer_table": f"0x{_pc_to_snes(POT_POINTER_TABLE_PC):06X}",
+            "pointer_count": DUNGEON_ROOM_COUNT,
+            "pointer_encoding": "bank16",
+            "pointer_bank": "0x01",
+            "strategy": "repack_all",
+            "data_regions": [_editor_range(start, end) for start, end in pot_regions],
+            "allocation_regions": [
+                _editor_range(start, end) for start, end in pot_regions
+            ],
+        },
+    }
+
+
+def derive_dungeon_stream_regions(dev_rom_path: Path) -> dict:
+    """Derive guarded object, sprite, and pot-item layouts from a dev ROM."""
+    try:
+        data = dev_rom_path.read_bytes()
+    except OSError as exc:
+        raise ManifestGenerationError(
+            f"Unable to read dev ROM {dev_rom_path}: {exc}"
+        ) from exc
+    return _derive_dungeon_stream_regions(data)
+
+
+def _find_custom_collision_stream_end(data: bytes, room_id: int, start_pc: int) -> int:
+    """Return the exclusive end of one validated custom-collision stream."""
+
+    def require_stream_span(cursor: int, size: int, label: str) -> None:
+        if (
+            cursor < CUSTOM_COLLISION_DATA_START_PC
+            or size < 0
+            or cursor + size > CUSTOM_COLLISION_DATA_END_PC
+        ):
+            raise ManifestGenerationError(
+                f"{label} for room 0x{room_id:03X} crosses reserved "
+                f"WaterFill data at PC 0x{CUSTOM_COLLISION_DATA_END_PC:X}"
+            )
+        _require_rom_span(data, cursor, size, label)
+
+    cursor = start_pc
+    single_tile_mode = False
+    while cursor < CUSTOM_COLLISION_DATA_END_PC:
+        require_stream_span(cursor, 2, "custom collision stream word")
+        word = _read_u16(
+            data,
+            cursor,
+            f"custom collision stream for room 0x{room_id:03X}",
+        )
+        cursor += 2
+        if word == 0xFFFF:
+            return cursor
+        if word == 0xF0F0:
+            single_tile_mode = True
+            continue
+        if single_tile_mode:
+            if word >= CUSTOM_COLLISION_MAP_TILES:
+                raise ManifestGenerationError(
+                    f"custom collision single-tile offset 0x{word:04X} for "
+                    f"room 0x{room_id:03X} is outside the 64x64 map"
+                )
+            require_stream_span(cursor, 1, "custom collision tile")
+            cursor += 1
+            continue
+
+        require_stream_span(cursor, 2, "custom collision rectangle dimensions")
+        width = _read_u8(
+            data,
+            cursor,
+            f"custom collision width for room 0x{room_id:03X}",
+        )
+        height = _read_u8(
+            data,
+            cursor + 1,
+            f"custom collision height for room 0x{room_id:03X}",
+        )
+        cursor += 2
+        if width == 0 or height == 0:
+            raise ManifestGenerationError(
+                f"custom collision rectangle for room 0x{room_id:03X} has "
+                f"zero dimension {width}x{height}"
+            )
+        row, column = divmod(word, CUSTOM_COLLISION_MAP_WIDTH)
+        if (
+            word >= CUSTOM_COLLISION_MAP_TILES
+            or column + width > CUSTOM_COLLISION_MAP_WIDTH
+            or row + height > CUSTOM_COLLISION_MAP_HEIGHT
+        ):
+            raise ManifestGenerationError(
+                f"custom collision rectangle for room 0x{room_id:03X} at "
+                f"offset 0x{word:04X} with size {width}x{height} exceeds "
+                "the 64x64 map"
+            )
+        payload_size = width * height
+        require_stream_span(cursor, payload_size, "custom collision rectangle")
+        cursor += payload_size
+
+    raise ManifestGenerationError(
+        f"custom collision stream for room 0x{room_id:03X} is unterminated "
+        f"before reserved WaterFill data at PC 0x{CUSTOM_COLLISION_DATA_END_PC:X}"
+    )
+
+
 def derive_editor_managed_regions(dev_rom_path: Path) -> list[dict]:
-    """Derive exact room-header and message-ID ranges from the dev ROM."""
+    """Derive exact dungeon metadata and collision ranges from the dev ROM."""
     try:
         data = dev_rom_path.read_bytes()
     except OSError as exc:
@@ -940,9 +1447,7 @@ def derive_editor_managed_regions(dev_rom_path: Path) -> list[dict]:
         DUNGEON_ROOM_COUNT * 2,
         "room-header pointer table",
     )
-    _require_rom_span(
-        data, ROOM_HEADER_BANK_PC, 1, "room-header pointer bank"
-    )
+    _require_rom_span(data, ROOM_HEADER_BANK_PC, 1, "room-header pointer bank")
     header_bank = data[ROOM_HEADER_BANK_PC]
 
     header_ranges: list[tuple[int, int]] = []
@@ -987,10 +1492,178 @@ def derive_editor_managed_regions(dev_rom_path: Path) -> list[dict]:
         "dungeon room message IDs",
     )
 
-    return [
-        _editor_range(sorted_headers[0][0], sorted_headers[-1][1]),
-        _editor_range(DUNGEON_MESSAGE_IDS_PC, messages_end_pc),
+    collision_pointer_table_end = (
+        CUSTOM_COLLISION_POINTER_TABLE_PC + DUNGEON_ROOM_COUNT * 3
+    )
+    _require_rom_span(
+        data,
+        CUSTOM_COLLISION_POINTER_TABLE_PC,
+        collision_pointer_table_end - CUSTOM_COLLISION_POINTER_TABLE_PC,
+        "custom-collision pointer table",
+    )
+    _require_rom_span(
+        data,
+        CUSTOM_COLLISION_DATA_START_PC,
+        CUSTOM_COLLISION_DATA_END_PC - CUSTOM_COLLISION_DATA_START_PC,
+        "custom-collision data region",
+    )
+    for room_id in range(DUNGEON_ROOM_COUNT):
+        raw_pointer = _read_u24(
+            data,
+            CUSTOM_COLLISION_POINTER_TABLE_PC + room_id * 3,
+            f"custom-collision pointer for room 0x{room_id:03X}",
+        )
+        if raw_pointer == 0:
+            continue
+        collision_pc = _strict_lorom_to_pc(
+            raw_pointer,
+            f"Custom-collision pointer for room 0x{room_id:03X}",
+        )
+        if not (
+            CUSTOM_COLLISION_DATA_START_PC
+            <= collision_pc
+            < CUSTOM_COLLISION_DATA_END_PC
+        ):
+            raise ManifestGenerationError(
+                f"custom-collision pointer for room 0x{room_id:03X} resolves "
+                f"to PC 0x{collision_pc:X}, outside the editor-owned region"
+            )
+        _find_custom_collision_stream_end(data, room_id, collision_pc)
+
+    named_regions = [
+        ("dungeon_message_ids", DUNGEON_MESSAGE_IDS_PC, messages_end_pc),
+        ("room_headers", sorted_headers[0][0], sorted_headers[-1][1]),
+        (
+            "custom_collision_pointers",
+            CUSTOM_COLLISION_POINTER_TABLE_PC,
+            collision_pointer_table_end,
+        ),
+        (
+            "custom_collision_data",
+            CUSTOM_COLLISION_DATA_START_PC,
+            CUSTOM_COLLISION_DATA_END_PC,
+        ),
     ]
+    _validate_disjoint_named_ranges(named_regions, "editor-managed regions")
+
+    return [
+        _editor_range(start, end)
+        for _, start, end in sorted(named_regions, key=lambda item: item[1])
+    ]
+
+
+def _validate_expanded_hooks_disjoint_from_editor_regions(
+    hooks: list[HookEntry], editor_regions: list[dict]
+) -> None:
+    """Reject expanded hooks that may extend into editor-owned bytes.
+
+    HookEntry records only a start address, not an exact source-backed end.
+    Within one physical LoROM bank, a hook beginning before an editor range's
+    exclusive end is therefore unsafe even when it starts just before the
+    range. A hook at or after the exclusive end remains disjoint.
+    """
+    editor_pc_ranges = [
+        (
+            _strict_lorom_to_pc(int(region["start"], 16), "Editor range start"),
+            _strict_lorom_to_pc(int(region["end"], 16), "Editor range end"),
+            region,
+        )
+        for region in editor_regions
+    ]
+    for hook in hooks:
+        physical = _physical_org_address(hook.address)
+        bank = (physical >> 16) & 0xFF
+        if bank in (0x7E, 0x7F) or bank < 0x1E:
+            continue
+        hook_start = _strict_lorom_to_pc(
+            physical, f"Expanded hook {hook.source}"
+        )
+        for region_start, region_end, region in editor_pc_ranges:
+            hook_bank_start = (hook_start // 0x8000) * 0x8000
+            hook_bank_end = hook_bank_start + 0x8000
+            region_segment_start = max(region_start, hook_bank_start)
+            region_segment_end = min(region_end, hook_bank_end)
+            if (
+                region_segment_start < region_segment_end
+                and hook_start < region_segment_end
+            ):
+                raise ManifestGenerationError(
+                    f"expanded hook {hook.source} at 0x{physical:06X} "
+                    f"starts before editor-managed range {region['start']}-"
+                    f"{region['end']} ends in the same physical LoROM bank; "
+                    "its exact end is unknown, so protected hooks must take "
+                    "precedence"
+                )
+
+
+def _validate_unresolved_org_proofs(
+    directives: list[OrgDirective], editor_regions: list[dict]
+) -> None:
+    """Require source-local bank proof for every active unresolved org."""
+    editor_banks: set[int] = set()
+    for region in editor_regions:
+        start_pc = _strict_lorom_to_pc(
+            int(region["start"], 16), "Editor range start"
+        )
+        end_pc = _strict_lorom_to_pc(
+            int(region["end"], 16), "Editor range end"
+        )
+        for bank in range(start_pc // 0x8000, (end_pc - 1) // 0x8000 + 1):
+            editor_banks.add(bank)
+
+    for directive in directives:
+        if directive.address is not None:
+            continue
+        if directive.proof_bank is None:
+            raise ManifestGenerationError(
+                f"{directive.source}: unresolved active org expression "
+                f"{directive.expression!r} has no @manifest-org-bank proof"
+            )
+        if re.search(r"<[^>]+>", directive.expression):
+            raise ManifestGenerationError(
+                f"{directive.source}: unresolved active org expression "
+                f"{directive.expression!r} contains a macro placeholder; "
+                "a single @manifest-org-bank proof cannot cover every "
+                "invocation"
+            )
+        physical_bank = directive.proof_bank & 0x7F
+        if physical_bank in (0x7E, 0x7F):
+            raise ManifestGenerationError(
+                f"{directive.source}: unresolved active org expression "
+                f"{directive.expression!r} claims WRAM bank proof "
+                f"0x{directive.proof_bank:02X}"
+            )
+        if directive.anchor_banks and (
+            len(directive.anchor_banks) != 1
+            or physical_bank != directive.anchor_banks[0]
+        ):
+            anchors = ", ".join(
+                f"0x{bank:02X}" for bank in directive.anchor_banks
+            )
+            raise ManifestGenerationError(
+                f"{directive.source}: unresolved active org expression "
+                f"{directive.expression!r} has address-literal bank anchor(s) "
+                f"{anchors}, contradicting @manifest-org-bank proof "
+                f"0x{directive.proof_bank:02X}"
+            )
+        if physical_bank in editor_banks:
+            raise ManifestGenerationError(
+                f"{directive.source}: unresolved active org expression "
+                f"{directive.expression!r} may affect editor-managed physical "
+                f"LoROM bank 0x{physical_bank:02X}"
+            )
+        source_path = directive.source.rsplit(":", 1)[0]
+        contract = (
+            source_path,
+            directive.expression,
+            directive.proof_bank,
+        )
+        if contract not in AUDITED_UNRESOLVED_ORG_CONTRACTS:
+            raise ManifestGenerationError(
+                f"{directive.source}: unresolved active org expression "
+                f"{directive.expression!r} is not an audited source/expression/"
+                "bank contract"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -1041,9 +1714,7 @@ def generate_manifest(
 
     # Load defines for conditional compilation evaluation
     defines = _load_global_defines(root)
-    asm_sources = filter_active_asm_sources(
-        root, reachable_sources, defines
-    )
+    asm_sources = reachable_sources
 
     # Scan only the source graph assembled from Oracle_main.asm. Local ignored
     # assets and archived experiments must not claim ROM ownership.
@@ -1104,13 +1775,24 @@ def generate_manifest(
     manifest["rom"] = rom_meta
 
     if dev_rom_path.exists():
+        manifest["dungeon_stream_regions"] = derive_dungeon_stream_regions(
+            dev_rom_path
+        )
+        editor_regions = derive_editor_managed_regions(dev_rom_path)
+        _validate_expanded_hooks_disjoint_from_editor_regions(
+            hooks, editor_regions
+        )
+        _validate_unresolved_org_proofs(
+            scan_org_directives(root, asm_sources), editor_regions
+        )
         manifest["editor_managed_regions"] = {
             "description": (
-                "Exact room-header and per-room message-ID ranges derived "
-                "from the editable dev ROM. Protected hooks still take "
-                "precedence."
+                "Exact yaze-owned dungeon metadata and custom-collision "
+                "ranges derived from the editable dev ROM. The WaterFill "
+                "tail beginning at $25:E000 remains ASM-owned, and protected "
+                "hooks still take precedence."
             ),
-            "regions": derive_editor_managed_regions(dev_rom_path),
+            "regions": editor_regions,
         }
 
     # Protected regions — these are hook addresses in VANILLA banks.

--- a/Scripts/Generate/generate_hooks_json.py
+++ b/Scripts/Generate/generate_hooks_json.py
@@ -16,7 +16,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Optional
 
-ORG_RE = re.compile(r'^\s*org\s+\$([0-9A-Fa-f]{6})\b')
+ORG_RE = re.compile(r'^\s*org\s+\$([0-9A-Fa-f]{1,6})(?=\s*(?::|;|$))')
+ORG_DIRECTIVE_RE = re.compile(r"^\s*org\s+([^:;]+)", re.IGNORECASE)
+ORG_BANK_PROOF_RE = re.compile(
+    r"@manifest-org-bank\s*=\s*\$?([0-9A-Fa-f]{2})\b",
+    re.IGNORECASE,
+)
 LABEL_RE = re.compile(r'^\s*[A-Za-z0-9_\.\+\-]+:\s*$')
 INSTR_RE = re.compile(r'^\s*([A-Za-z]{2,5})\b\s*(.*)$')
 COMMENT_RE = re.compile(r'^\s*;')
@@ -39,13 +44,21 @@ HOOK_DIRECTIVE_RE = re.compile(r'@hook\b(.*)', re.IGNORECASE)
 HOOK_KV_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)=(\"[^\"]*\"|'[^']*'|\S+)")
 
 DEFINE_ASSIGN_RE = re.compile(
-    r"^\s*!([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(\$[0-9A-Fa-f]+|0x[0-9A-Fa-f]+|\d+)\b"
+    r"^\s*!([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+?)\s*$"
 )
 DEFINE_REF_RE = re.compile(r"!([A-Za-z_][A-Za-z0-9_]*)\b")
+DEFINE_ANY_ASSIGN_RE = re.compile(
+    r"^\s*!([A-Za-z_][A-Za-z0-9_]*)\s*(#=|=)\s*(.*?)\s*$"
+)
 HEX_LITERAL_RE = re.compile(r"\$([0-9A-Fa-f]+)\b")
 IF_DIRECTIVE_RE = re.compile(r"^\s*(if|elseif)\b(.*)$", re.IGNORECASE)
 ELSE_DIRECTIVE_RE = re.compile(r"^\s*else\b", re.IGNORECASE)
 ENDIF_DIRECTIVE_RE = re.compile(r"^\s*endif\b", re.IGNORECASE)
+MACRO_START_RE = re.compile(
+    r"^\s*macro\s+([A-Za-z_][A-Za-z0-9_]*)\b", re.IGNORECASE
+)
+MACRO_END_RE = re.compile(r"^\s*endmacro\b", re.IGNORECASE)
+MACRO_INVOKE_RE = re.compile(r"^\s*%([A-Za-z_][A-Za-z0-9_]*)\s*\(")
 
 SKIP_DIRS = {
     '.git', '.context', '.claude', '.cursor',
@@ -96,6 +109,14 @@ KIND_PRIORITY = {
     'patch': 2,
     'data': 1,
 }
+PROTECTED_SIZE_ESTIMATE = {
+    "jsl": 4,
+    "jml": 4,
+    "jsr": 3,
+    "jmp": 3,
+    "data": 8,
+    "patch": 4,
+}
 
 @dataclass
 class HookEntry:
@@ -112,6 +133,17 @@ class HookEntry:
     expected_x: Optional[int] = None
     expected_exit_m: Optional[int] = None
     expected_exit_x: Optional[int] = None
+    protected_size: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class OrgDirective:
+    expression: str
+    address: Optional[int]
+    source: str
+    proof_bank: Optional[int] = None
+    macro_name: Optional[str] = None
+    anchor_banks: tuple[int, ...] = ()
 
 
 def _module_from_path(path: Path, root: Path) -> str:
@@ -153,7 +185,7 @@ def _scan_annotations(lines: list[str], start_idx: int) -> tuple[str, bool, Opti
 
     for j in range(start_idx, min(start_idx + 20, len(lines))):
         line = lines[j]
-        if ORG_RE.match(line) and j != start_idx:
+        if ORG_DIRECTIVE_RE.match(line) and j != start_idx:
             break
         if COMMENT_RE.match(line) or ';' in line:
             m = ABI_RE.search(line)
@@ -198,7 +230,7 @@ def _scan_hook_directive(lines: list[str], start_idx: int) -> dict:
     directive: dict[str, object] = {}
     for j in range(start_idx, min(start_idx + 20, len(lines))):
         line = lines[j]
-        if ORG_RE.match(line) and j != start_idx:
+        if ORG_DIRECTIVE_RE.match(line) and j != start_idx:
             break
         if ";" in line:
             comment = line.split(";", 1)[1]
@@ -215,12 +247,15 @@ def _scan_hook_directive(lines: list[str], start_idx: int) -> dict:
     return directive
 
 
-def _parse_define_assignment(line: str) -> tuple[str, int] | None:
-    m = DEFINE_ASSIGN_RE.match(line)
+def _parse_define_assignment(
+    line: str, defines: Optional[dict[str, int]] = None
+) -> tuple[str, int] | None:
+    source = line.split(";", 1)[0]
+    m = DEFINE_ASSIGN_RE.match(source)
     if not m:
         return None
     name = m.group(1).strip()
-    value = _parse_int(m.group(2))
+    value = _eval_numeric_expression(m.group(2), defines or {})
     if value is None:
         return None
     return name, value
@@ -234,7 +269,7 @@ def _load_global_defines(root: Path) -> dict[str, int]:
         if not path.exists():
             continue
         for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
-            parsed = _parse_define_assignment(line)
+            parsed = _parse_define_assignment(line, defines)
             if parsed is None:
                 continue
             name, value = parsed
@@ -337,6 +372,58 @@ def _eval_condition(expr: str, defines: dict[str, int]) -> Optional[bool]:
         return None
 
 
+def _eval_numeric_expression(
+    expr: str, defines: dict[str, int]
+) -> Optional[int]:
+    """Evaluate a simple numeric Asar expression, or return None."""
+    raw = expr.split(";", 1)[0].strip()
+    if not raw:
+        return None
+    unknown = False
+
+    def repl(m: re.Match) -> str:
+        nonlocal unknown
+        name = m.group(1)
+        if name not in defines:
+            unknown = True
+            return "0"
+        return str(defines[name])
+
+    cooked = DEFINE_REF_RE.sub(repl, raw)
+    if unknown:
+        return None
+    cooked = HEX_LITERAL_RE.sub(lambda m: f"0x{m.group(1)}", cooked)
+    try:
+        tree = ast.parse(cooked, mode="eval")
+        value = _eval_ast(tree)
+    except Exception:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    return int(value)
+
+
+def _expression_address_anchor_banks(
+    expr: str, defines: Optional[dict[str, int]] = None
+) -> tuple[int, ...]:
+    """Return physical LoROM banks named by literals or known defines."""
+    banks: set[int] = set()
+    for match in HEX_LITERAL_RE.finditer(expr):
+        value = int(match.group(1), 16)
+        if value <= 0xFFFFFF and (value & 0xFFFF) >= 0x8000:
+            banks.add((value >> 16) & 0x7F)
+    known_defines = defines or {}
+    for match in DEFINE_REF_RE.finditer(expr):
+        value = known_defines.get(match.group(1))
+        if (
+            value is not None
+            and 0 <= value <= 0xFFFFFF
+            and (value & 0xFFFF) >= 0x8000
+        ):
+            banks.add((value >> 16) & 0x7F)
+    return tuple(sorted(banks))
+
+
 def _inline_org_payload(line: str) -> tuple[str, Optional[str]] | None:
     """Return the opcode/target if the org payload is on the same line.
 
@@ -368,6 +455,7 @@ def _first_instruction(lines: list[str], start_idx: int, defines: dict[str, int]
     if inline is not None:
         return inline
 
+    defines = dict(defines)
     active = True
     stack: list[dict[str, object]] = []
 
@@ -386,6 +474,10 @@ def _first_instruction(lines: list[str], start_idx: int, defines: dict[str, int]
             expr = m_if.group(2).strip()
             parent_active = active
             cond = _eval_condition(expr, defines)
+            if cond is None:
+                # The payload could be any feasible branch. Use the largest
+                # protected-size classification rather than understate it.
+                return "data", None
             cond_val = bool(cond) if cond is not None else True
             if kind == "if":
                 branch_taken = parent_active and cond_val
@@ -420,6 +512,18 @@ def _first_instruction(lines: list[str], start_idx: int, defines: dict[str, int]
             continue
 
         if not active:
+            continue
+
+        parsed_define = _parse_define_assignment(raw_line, defines)
+        if parsed_define is not None:
+            name, value = parsed_define
+            defines[name] = value
+            continue
+        assignment = DEFINE_ANY_ASSIGN_RE.match(
+            raw_line.split(";", 1)[0]
+        )
+        if assignment:
+            defines.pop(assignment.group(1), None)
             continue
 
         if LABEL_RE.match(line):
@@ -487,6 +591,208 @@ def filter_active_asm_sources(
     return active_sources
 
 
+def _iter_active_lines(
+    lines: list[str], initial_defines: dict[str, int]
+) -> Iterable[tuple[int, str, dict[str, int]]]:
+    """Yield active source lines with the numeric define state at that line."""
+    defines = dict(initial_defines)
+    active = True
+    stack: list[dict[str, object]] = []
+    for idx, line in enumerate(lines):
+        directive = line.split(";", 1)[0].strip()
+        m_if = IF_DIRECTIVE_RE.match(directive)
+        if m_if:
+            kind = m_if.group(1).lower()
+            condition_defines = (
+                dict(stack[-1]["entry_defines"])
+                if kind == "elseif" and stack
+                else defines
+            )
+            cond = _eval_condition(
+                m_if.group(2).strip(), condition_defines
+            )
+            if kind == "if":
+                parent_active = active
+                active = parent_active and cond is not False
+                stack.append(
+                    {
+                        "parent_active": parent_active,
+                        "entry_defines": dict(defines),
+                        "branch_states": [],
+                        "current_branch_active": active,
+                        "fallthrough_possible": (
+                            parent_active and cond is not True
+                        ),
+                    }
+                )
+            elif stack:
+                frame = stack[-1]
+                if bool(frame["current_branch_active"]):
+                    frame["branch_states"].append(dict(defines))
+                defines = dict(frame["entry_defines"])
+                fallthrough = bool(frame["fallthrough_possible"])
+                active = fallthrough and cond is not False
+                frame["current_branch_active"] = active
+                frame["fallthrough_possible"] = (
+                    fallthrough and cond is not True
+                )
+            continue
+        if ELSE_DIRECTIVE_RE.match(directive):
+            if stack:
+                frame = stack[-1]
+                if bool(frame["current_branch_active"]):
+                    frame["branch_states"].append(dict(defines))
+                defines = dict(frame["entry_defines"])
+                active = bool(frame["fallthrough_possible"])
+                frame["current_branch_active"] = active
+                frame["fallthrough_possible"] = False
+            continue
+        if ENDIF_DIRECTIVE_RE.match(directive):
+            if stack:
+                frame = stack.pop()
+                branch_states = frame["branch_states"]
+                if bool(frame["current_branch_active"]):
+                    branch_states.append(dict(defines))
+                if bool(frame["fallthrough_possible"]):
+                    branch_states.append(dict(frame["entry_defines"]))
+                if branch_states:
+                    common_names = set(branch_states[0])
+                    for state in branch_states[1:]:
+                        common_names.intersection_update(state)
+                    defines = {
+                        name: branch_states[0][name]
+                        for name in common_names
+                        if all(
+                            state[name] == branch_states[0][name]
+                            for state in branch_states[1:]
+                        )
+                    }
+                else:
+                    defines = dict(frame["entry_defines"])
+                active = bool(frame["parent_active"])
+            continue
+        if not active:
+            continue
+
+        parsed = _parse_define_assignment(line, defines)
+        if parsed is not None:
+            name, value = parsed
+            defines[name] = value
+        else:
+            assigned = DEFINE_ANY_ASSIGN_RE.match(line.split(";", 1)[0])
+            if assigned:
+                defines.pop(assigned.group(1), None)
+        yield idx, line, dict(defines)
+
+
+def scan_org_directives(
+    root: Path,
+    asm_paths: Optional[Iterable[Path]] = None,
+) -> list[OrgDirective]:
+    """Scan active literal/computed org directives with explicit proofs.
+
+    Org directives inside macro definitions are considered active only when
+    that macro is reachable from a real invocation in active source. This
+    keeps unused macro templates from becoming false hooks while ensuring an
+    invoked unresolved template cannot silently bypass manifest validation.
+    """
+    root = root.resolve()
+    explicit_sources = asm_paths is not None
+    global_defines = _load_global_defines(root)
+    source_paths = list(root.rglob("*.asm") if asm_paths is None else asm_paths)
+    active_sources = (
+        list(source_paths)
+        if explicit_sources
+        else filter_active_asm_sources(root, source_paths, global_defines)
+    )
+    records_by_path: dict[
+        Path, list[tuple[int, str, dict[str, int]]]
+    ] = {}
+    for source_path in active_sources:
+        asm_path = source_path.resolve()
+        if not explicit_sources and _should_skip(asm_path):
+            continue
+        try:
+            lines = asm_path.read_text(
+                encoding="utf-8", errors="ignore"
+            ).splitlines()
+        except OSError:
+            if explicit_sources:
+                raise
+            continue
+        records_by_path[asm_path] = list(
+            _iter_active_lines(lines, global_defines)
+        )
+
+    root_invocations: set[str] = set()
+    macro_edges: dict[str, set[str]] = {}
+    for records in records_by_path.values():
+        macro_name: Optional[str] = None
+        for _, line, _ in records:
+            source = line.split(";", 1)[0]
+            macro_start = MACRO_START_RE.match(source)
+            if macro_start:
+                macro_name = macro_start.group(1).lower()
+                macro_edges.setdefault(macro_name, set())
+                continue
+            if MACRO_END_RE.match(source):
+                macro_name = None
+                continue
+            invocation = MACRO_INVOKE_RE.match(source)
+            if not invocation:
+                continue
+            invoked = invocation.group(1).lower()
+            if macro_name is None:
+                root_invocations.add(invoked)
+            else:
+                macro_edges.setdefault(macro_name, set()).add(invoked)
+
+    active_macros = set(root_invocations)
+    pending = list(root_invocations)
+    while pending:
+        macro_name = pending.pop()
+        for invoked in macro_edges.get(macro_name, set()):
+            if invoked not in active_macros:
+                active_macros.add(invoked)
+                pending.append(invoked)
+
+    directives: list[OrgDirective] = []
+    for asm_path, records in records_by_path.items():
+        macro_name = None
+        for idx, line, defines in records:
+            source_text = line.split(";", 1)[0]
+            macro_start = MACRO_START_RE.match(source_text)
+            if macro_start:
+                macro_name = macro_start.group(1).lower()
+                continue
+            if MACRO_END_RE.match(source_text):
+                macro_name = None
+                continue
+            match = ORG_DIRECTIVE_RE.match(source_text)
+            if not match or (
+                macro_name is not None and macro_name not in active_macros
+            ):
+                continue
+            expression = match.group(1).strip()
+            proof_match = ORG_BANK_PROOF_RE.search(line)
+            proof_bank = (
+                int(proof_match.group(1), 16) if proof_match else None
+            )
+            directives.append(
+                OrgDirective(
+                    expression=expression,
+                    address=_eval_numeric_expression(expression, defines),
+                    source=f"{asm_path.relative_to(root)}:{idx + 1}",
+                    proof_bank=proof_bank,
+                    macro_name=macro_name,
+                    anchor_banks=_expression_address_anchor_banks(
+                        expression, defines
+                    ),
+                )
+            )
+    return directives
+
+
 def scan_hooks(
     root: Path,
     asm_paths: Optional[Iterable[Path]] = None,
@@ -497,15 +803,22 @@ def scan_hooks(
 
     global_defines = _load_global_defines(root)
     source_paths = root.rglob('*.asm') if asm_paths is None else asm_paths
-    active_sources = filter_active_asm_sources(
-        root, source_paths, global_defines
+    active_sources = (
+        list(source_paths)
+        if explicit_sources
+        else filter_active_asm_sources(root, source_paths, global_defines)
     )
+    active_macros = {
+        directive.macro_name
+        for directive in scan_org_directives(root, active_sources)
+        if directive.macro_name is not None
+    }
     for source_path in active_sources:
         asm_path = source_path.resolve()
         if not explicit_sources and _should_skip(asm_path):
             continue
         try:
-            rel = asm_path.relative_to(root)
+            asm_path.relative_to(root)
         except ValueError:
             if explicit_sources:
                 raise ValueError(
@@ -519,63 +832,24 @@ def scan_hooks(
                 raise
             continue
 
-        defines = dict(global_defines)
-        active = True
-        stack: list[dict[str, object]] = []
-        for idx, line in enumerate(lines):
-            # Conditional compilation (best-effort) so hooks.json matches the
-            # ROM when feature/module flags toggle entire org blocks.
-            directive = line.split(";", 1)[0].strip()
-            m_if = IF_DIRECTIVE_RE.match(directive)
-            if m_if:
-                kind = m_if.group(1).lower()
-                expr = m_if.group(2).strip()
-                parent_active = active
-                cond = _eval_condition(expr, defines)
-                cond_val = bool(cond) if cond is not None else True
-                if kind == "if":
-                    branch_taken = parent_active and cond_val
-                    active = parent_active and cond_val
-                    stack.append({"parent_active": parent_active, "branch_taken": branch_taken})
-                else:  # elseif
-                    if not stack:
-                        continue
-                    frame = stack[-1]
-                    parent_active = bool(frame["parent_active"])
-                    already = bool(frame["branch_taken"])
-                    if not parent_active or already:
-                        active = False
-                    else:
-                        active = parent_active and cond_val
-                        frame["branch_taken"] = active
+        macro_name: Optional[str] = None
+        for idx, line, defines in _iter_active_lines(lines, global_defines):
+            source_text = line.split(";", 1)[0]
+            macro_start = MACRO_START_RE.match(source_text)
+            if macro_start:
+                macro_name = macro_start.group(1).lower()
                 continue
-            if ELSE_DIRECTIVE_RE.match(directive):
-                if not stack:
-                    continue
-                frame = stack[-1]
-                parent_active = bool(frame["parent_active"])
-                already = bool(frame["branch_taken"])
-                active = parent_active and not already
-                frame["branch_taken"] = True
+            if MACRO_END_RE.match(source_text):
+                macro_name = None
                 continue
-            if ENDIF_DIRECTIVE_RE.match(directive):
-                if not stack:
-                    continue
-                frame = stack.pop()
-                active = bool(frame["parent_active"])
+            m = ORG_DIRECTIVE_RE.match(source_text)
+            if not m or (
+                macro_name is not None and macro_name not in active_macros
+            ):
                 continue
-
-            if not active:
+            addr = _eval_numeric_expression(m.group(1), defines)
+            if addr is None:
                 continue
-
-            parsed = _parse_define_assignment(line)
-            if parsed is not None:
-                name, value = parsed
-                defines[name] = value
-            m = ORG_RE.match(line)
-            if not m:
-                continue
-            addr = int(m.group(1), 16)
             kind, target = _first_instruction(lines, idx, defines)
             abi_class_note, no_return, ann_m, ann_x = _scan_annotations(lines, idx)
             hook_directive = _scan_hook_directive(lines, idx)
@@ -644,9 +918,17 @@ def scan_hooks(
                 expected_x=ann_x,
                 expected_exit_m=ann_exit_m,
                 expected_exit_x=ann_exit_x,
+                protected_size=PROTECTED_SIZE_ESTIMATE.get(kind, 4),
             )
 
             existing = hooks_by_addr.get(addr)
+            if existing:
+                maximum_size = max(
+                    existing.protected_size or 4,
+                    entry.protected_size or 4,
+                )
+                existing.protected_size = maximum_size
+                entry.protected_size = maximum_size
             if not existing or _score_entry(entry) > _score_entry(existing):
                 hooks_by_addr[addr] = entry
 

--- a/Scripts/Generate/tests/test_custom_collision_source_contract.py
+++ b/Scripts/Generate/tests/test_custom_collision_source_contract.py
@@ -75,6 +75,21 @@ class CustomCollisionSourceContractTest(unittest.TestCase):
         rom_path.write_bytes(data)
         return rom_path
 
+    def write_rom_with_raw_pointer(
+        self,
+        root: Path,
+        room_id: int,
+        snes_pointer: int,
+    ) -> Path:
+        rom_path = self.write_raw_rom(root, {})
+        data = bytearray(rom_path.read_bytes())
+        pointer_offset = POINTER_TABLE_START + (room_id * 3)
+        data[pointer_offset : pointer_offset + 3] = snes_pointer.to_bytes(
+            3, "little"
+        )
+        rom_path.write_bytes(data)
+        return rom_path
+
     def test_repository_source_is_complete(self) -> None:
         contract = validate_contract(REPO_ROOT)
 
@@ -161,6 +176,47 @@ class CustomCollisionSourceContractTest(unittest.TestCase):
             self.assertEqual(contract.room_count, 1)
             self.assertEqual(contract.tile_count, 2)
             self.assertIsNotNone(contract.rom_sha256)
+
+    def test_rom_zero_dimension_rectangle_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_source(root, [])
+            stream = b"\x00\x00\x00\x01\xFF\xFF"
+            rom_path = self.write_raw_rom(root, {0x25: stream})
+
+            with self.assertRaisesRegex(
+                CustomCollisionSourceContractError,
+                "zero-dimension collision rectangle 0x1",
+            ):
+                validate_contract(root, rom_path)
+
+    def test_rom_single_tile_offset_0x1000_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_source(root, [])
+            stream = b"\xF0\xF0\x00\x10\x07\xFF\xFF"
+            rom_path = self.write_raw_rom(root, {0x25: stream})
+
+            with self.assertRaisesRegex(
+                CustomCollisionSourceContractError,
+                "out-of-range single-tile offset 4096",
+            ):
+                validate_contract(root, rom_path)
+
+    def test_rom_rectangle_footprint_crossing_map_edge_fails_closed(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_source(root, [])
+            stream = b"\xFF\x0F\x02\x01\x01\x02\xFF\xFF"
+            rom_path = self.write_raw_rom(root, {0x25: stream})
+
+            with self.assertRaisesRegex(
+                CustomCollisionSourceContractError,
+                "rectangle at offset 4095 with size 2x1",
+            ):
+                validate_contract(root, rom_path)
 
     def test_rom_rectangle_then_single_tile_overwrite_and_clear(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -279,6 +335,36 @@ class CustomCollisionSourceContractTest(unittest.TestCase):
                 "maps outside collision data",
             ):
                 validate_contract(root, rom_path)
+
+    def test_rom_raw_low_half_pointer_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_source(root, [])
+            rom_path = self.write_rom_with_raw_pointer(
+                root, 0x25, 0x250450
+            )
+
+            with self.assertRaisesRegex(
+                CustomCollisionSourceContractError,
+                r"pointer 0x250450 is a raw low-half LoROM address",
+            ):
+                validate_contract(root, rom_path)
+
+    def test_rom_wram_banks_and_fastrom_mirrors_fail_closed(self) -> None:
+        for pointer in (0x7E8450, 0x7F8450, 0xFE8450, 0xFF8450):
+            with self.subTest(pointer=f"0x{pointer:06X}"):
+                with tempfile.TemporaryDirectory() as directory:
+                    root = Path(directory)
+                    self.write_source(root, [])
+                    rom_path = self.write_rom_with_raw_pointer(
+                        root, 0x25, pointer
+                    )
+
+                    with self.assertRaisesRegex(
+                        CustomCollisionSourceContractError,
+                        r"uses WRAM bank or mirror 0x(?:7E|7F|FE|FF)",
+                    ):
+                        validate_contract(root, rom_path)
 
     def test_rom_all_zero_pointer_is_omitted_like_z3ed_export(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/Scripts/Generate/tests/test_generate_hack_manifest.py
+++ b/Scripts/Generate/tests/test_generate_hack_manifest.py
@@ -13,18 +13,31 @@ REPO_ROOT = GENERATE_DIR.parents[1]
 sys.path.insert(0, str(GENERATE_DIR))
 
 from generate_hack_manifest import (  # noqa: E402
+    CUSTOM_COLLISION_DATA_END_PC,
+    CUSTOM_COLLISION_DATA_START_PC,
+    CUSTOM_COLLISION_POINTER_TABLE_PC,
     DUNGEON_MESSAGE_IDS_PC,
     DUNGEON_ROOM_COUNT,
+    OBJECT_DATA_REGIONS_PC,
+    OBJECT_TABLE_POINTER_OPERAND_PC,
+    POT_DATA_START_PC,
+    POT_DATA_END_PC,
+    POT_POINTER_TABLE_PC,
     ROOM_HEADER_BANK_PC,
     ROOM_HEADER_POINTER_PC,
+    SPRITE_DATA_END_PC,
+    SPRITE_TABLE_POINTER_OPERAND_PC,
     ManifestGenerationError,
     _pc_to_snes,
+    _snes_to_pc,
+    _strict_lorom_to_pc,
     collect_reachable_asm_sources,
     compute_protected_regions,
+    derive_dungeon_stream_regions,
     derive_editor_managed_regions,
     generate_manifest,
 )
-from generate_hooks_json import HookEntry  # noqa: E402
+from generate_hooks_json import HookEntry, scan_hooks  # noqa: E402
 
 
 class ManifestFixture:
@@ -42,10 +55,36 @@ class ManifestFixture:
         return path
 
     def write_dev_rom(self, duplicate_room: int | None = None) -> Path:
-        data = bytearray(0x120000)
+        data = bytearray(0x200000)
+
+        object_table_pc = 0xF8000
+        data[OBJECT_TABLE_POINTER_OPERAND_PC : OBJECT_TABLE_POINTER_OPERAND_PC + 3] = (
+            _pc_to_snes(object_table_pc).to_bytes(3, "little")
+        )
+        for room_id in range(DUNGEON_ROOM_COUNT):
+            pointer_pc = object_table_pc + room_id * 3
+            data[pointer_pc : pointer_pc + 3] = _pc_to_snes(0x50000).to_bytes(
+                3, "little"
+            )
+        data[0x50000 : 0x50008] = b"\x00\x00\xFF\xFF\xFF\xFF\xFF\xFF"
+
+        sprite_table_pc = 0x4D2B2
+        data[SPRITE_TABLE_POINTER_OPERAND_PC : SPRITE_TABLE_POINTER_OPERAND_PC + 2] = (
+            _pc_to_snes(sprite_table_pc) & 0xFFFF
+        ).to_bytes(2, "little")
+        for room_id in range(DUNGEON_ROOM_COUNT):
+            pointer_pc = sprite_table_pc + room_id * 2
+            data[pointer_pc : pointer_pc + 2] = (0xD502).to_bytes(2, "little")
+        data[0x4D502 : 0x4D504] = b"\x00\xFF"
+
+        for room_id in range(DUNGEON_ROOM_COUNT):
+            pointer_pc = POT_POINTER_TABLE_PC + room_id * 2
+            data[pointer_pc : pointer_pc + 2] = (0xDDE7).to_bytes(2, "little")
+        data[POT_DATA_START_PC : POT_DATA_START_PC + 2] = b"\xFF\xFF"
+
         header_table_pc = 0x110000
         header_table_snes = _pc_to_snes(header_table_pc)
-        data[ROOM_HEADER_POINTER_PC:ROOM_HEADER_POINTER_PC + 3] = (
+        data[ROOM_HEADER_POINTER_PC : ROOM_HEADER_POINTER_PC + 3] = (
             header_table_snes.to_bytes(3, "little")
         )
         data[ROOM_HEADER_BANK_PC] = 0x22
@@ -59,12 +98,17 @@ class ManifestFixture:
             )
             header_offset = first_header_offset + source_room * 14
             pointer_pc = header_table_pc + room_id * 2
-            data[pointer_pc:pointer_pc + 2] = header_offset.to_bytes(
-                2, "little"
-            )
+            data[pointer_pc : pointer_pc + 2] = header_offset.to_bytes(2, "little")
 
         message_end = DUNGEON_MESSAGE_IDS_PC + DUNGEON_ROOM_COUNT * 2
         self.assert_span_fits(data, DUNGEON_MESSAGE_IDS_PC, message_end)
+
+        data[
+            CUSTOM_COLLISION_POINTER_TABLE_PC : CUSTOM_COLLISION_POINTER_TABLE_PC + 3
+        ] = _pc_to_snes(CUSTOM_COLLISION_DATA_START_PC).to_bytes(3, "little")
+        data[CUSTOM_COLLISION_DATA_START_PC : CUSTOM_COLLISION_DATA_START_PC + 4] = (
+            b"\xf0\xf0\xff\xff"
+        )
 
         rom_path = self.root / "Roms" / "oos168.sfc"
         rom_path.parent.mkdir(parents=True, exist_ok=True)
@@ -88,6 +132,33 @@ class ManifestFixture:
             raise AssertionError(
                 f"Fixture span [0x{start:X}, 0x{end:X}) does not fit"
             )
+
+
+class LoRomConversionTest(unittest.TestCase):
+    def test_wram_fastrom_mirrors_are_rejected(self) -> None:
+        for address in (0xFE8000, 0xFF8000):
+            with self.subTest(address=f"0x{address:06X}"):
+                with self.assertRaisesRegex(
+                    ManifestGenerationError, "WRAM or its FastROM mirror"
+                ):
+                    _strict_lorom_to_pc(address, "fixture pointer")
+                with self.assertRaisesRegex(
+                    ManifestGenerationError, "WRAM or its FastROM mirror"
+                ):
+                    _snes_to_pc(address)
+
+    def test_pc_offsets_stop_before_wram_backed_window(self) -> None:
+        self.assertEqual(_pc_to_snes(0x3EFFFF), 0x7DFFFF)
+        self.assertEqual(
+            _strict_lorom_to_pc(0x7DFFFF, "fixture pointer"),
+            0x3EFFFF,
+        )
+        for address in (0x3F0000, 0x3FFFFF):
+            with self.subTest(address=f"0x{address:X}"):
+                with self.assertRaisesRegex(
+                    ManifestGenerationError, "outside canonical ROM-backed LoROM"
+                ):
+                    _pc_to_snes(address)
 
 
 class ReachableSourceTest(unittest.TestCase):
@@ -236,6 +307,171 @@ class ReachableSourceTest(unittest.TestCase):
             },
         )
 
+    def test_unknown_cross_file_include_condition_unions_both_branches(
+        self,
+    ) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm",
+            'incsrc "Core/defs.asm"\nincsrc "Core/select.asm"\n',
+        )
+        self.fixture.write_text("Core/defs.asm", "!FLAG = 0\n")
+        self.fixture.write_text(
+            "Core/select.asm",
+            "if !FLAG == 1\n"
+            '  incsrc "safe.asm"\n'
+            "else\n"
+            '  incsrc "unsafe.asm"\n'
+            "endif\n",
+        )
+        self.fixture.write_text("Core/safe.asm", "org $0E9000\ndb $00\n")
+        self.fixture.write_text(
+            "Core/unsafe.asm", "org $258500\ndb $00\n"
+        )
+        rom_path = self.fixture.write_dev_rom()
+
+        sources = {
+            path.relative_to(self.fixture.root.resolve()).as_posix()
+            for path in collect_reachable_asm_sources(self.fixture.root)
+        }
+        self.assertIn("Core/unsafe.asm", sources)
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            r"expanded hook Core/unsafe\.asm:1 at 0x258500 starts before",
+        ):
+            generate_manifest(self.fixture.root, dev_rom_path=rom_path)
+
+    def test_unknown_hook_payload_uses_conservative_data_size(self) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm", 'incsrc "Core/active.asm"\n'
+        )
+        self.fixture.write_text(
+            "Core/active.asm",
+            "org $0E9000\n"
+            "if !UNKNOWN_PAYLOAD\n"
+            "  JSL MaybeShortHook\n"
+            "else\n"
+            "  db $00,$00,$00,$00,$00,$00,$00,$00\n"
+            "endif\n",
+        )
+
+        hooks = scan_hooks(
+            self.fixture.root,
+            collect_reachable_asm_sources(self.fixture.root),
+        )
+        regions = compute_protected_regions(hooks)
+
+        self.assertEqual(hooks[0].kind, "data")
+        self.assertEqual(regions[0]["size"], 8)
+
+    def test_reachable_global_flag_override_fails_closed(self) -> None:
+        self.fixture.write_text("Config/module_flags.asm", "!FLAG = 0\n")
+        self.fixture.write_text(
+            "Oracle_main.asm",
+            'incsrc "Config/module_flags.asm"\n'
+            'incsrc "Core/override.asm"\n'
+            "if !FLAG == 1\n"
+            '  incsrc "Core/danger.asm"\n'
+            "endif\n",
+        )
+        self.fixture.write_text("Core/override.asm", "!FLAG = 1\n")
+        self.fixture.write_text("Core/danger.asm", "org $258448\ndb $00\n")
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            r"Core/override\.asm:1: reachable source reassigns preloaded "
+            r"global define !FLAG outside the canonical define files",
+        ):
+            collect_reachable_asm_sources(self.fixture.root)
+
+    def test_reachable_global_target_override_fails_closed(self) -> None:
+        self.fixture.write_text(
+            "Config/feature_flags.asm", "!TARGET = $0E9000\n"
+        )
+        self.fixture.write_text(
+            "Oracle_main.asm",
+            'incsrc "Config/feature_flags.asm"\n'
+            'incsrc "Core/override.asm"\n'
+            'incsrc "Core/patch.asm"\n',
+        )
+        self.fixture.write_text("Core/override.asm", "!TARGET = $258448\n")
+        self.fixture.write_text("Core/patch.asm", "org !TARGET\ndb $00\n")
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            r"Core/override\.asm:1: reachable source reassigns preloaded "
+            r"global define !TARGET outside the canonical define files",
+        ):
+            generate_manifest(self.fixture.root)
+
+    def test_literal_include_under_disabled_module_root_remains_reachable(
+        self,
+    ) -> None:
+        self.fixture.write_text(
+            "Config/module_flags.asm", "!DISABLE_SPRITES = 1\n"
+        )
+        self.fixture.write_text(
+            "Oracle_main.asm", 'incsrc "Sprites/explicit.asm"\n'
+        )
+        self.fixture.write_text("Sprites/explicit.asm", "org $0E9000\ndb $00\n")
+
+        sources = collect_reachable_asm_sources(self.fixture.root)
+        hooks = scan_hooks(self.fixture.root, sources)
+
+        self.assertIn(
+            "Sprites/explicit.asm",
+            {
+                path.relative_to(self.fixture.root.resolve()).as_posix()
+                for path in sources
+            },
+        )
+        self.assertEqual([hook.address for hook in hooks], [0x0E9000])
+
+    def test_duplicate_possible_hooks_preserve_maximum_protected_size(
+        self,
+    ) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm", 'incsrc "Core/active.asm"\n'
+        )
+        self.fixture.write_text(
+            "Core/active.asm",
+            'if defined("USE_JSL")\n'
+            "  org $0D9000\n"
+            "  JSL Foo\n"
+            "else\n"
+            "  org $0D9000\n"
+            "  db $00,$01,$02,$03,$04,$05,$06,$07\n"
+            "endif\n",
+        )
+
+        hooks = scan_hooks(
+            self.fixture.root,
+            collect_reachable_asm_sources(self.fixture.root),
+        )
+        regions = compute_protected_regions(hooks)
+
+        self.assertEqual(hooks[0].kind, "jsl")
+        self.assertEqual(hooks[0].protected_size, 8)
+        self.assertEqual(regions[0]["size"], 8)
+
+    def test_hook_payload_scanner_applies_local_define_mutations(self) -> None:
+        self.fixture.write_text("Config/feature_flags.asm", "!MODE = 1\n")
+        active_path = self.fixture.write_text(
+            "Core/active.asm",
+            "org $0D9000\n"
+            "!MODE = 0\n"
+            "if !MODE\n"
+            "  JSL Foo\n"
+            "else\n"
+            "  db $00,$01,$02,$03,$04,$05,$06,$07\n"
+            "endif\n",
+        )
+
+        hooks = scan_hooks(self.fixture.root, [active_path])
+        regions = compute_protected_regions(hooks)
+
+        self.assertEqual(hooks[0].kind, "data")
+        self.assertEqual(regions[0]["size"], 8)
+
     def test_manifest_excludes_unreachable_bank_claims_and_hooks(self) -> None:
         self.fixture.write_text(
             "Oracle_main.asm", 'incsrc "Core/active.asm"\n'
@@ -320,7 +556,388 @@ class ReachableSourceTest(unittest.TestCase):
             {"0x20AF20", "0x20F000"},
         )
 
-    def test_disabled_overworld_incsrc_cannot_leak_manifest_state(
+    def test_expanded_hook_cannot_overlap_editor_managed_range(self) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm", 'incsrc "Core/active.asm"\n'
+        )
+        self.fixture.write_text(
+            "Core/active.asm",
+            "org $258500\n"
+            "JSL ExpandedCollisionHook\n",
+        )
+        rom_path = self.fixture.write_dev_rom()
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            r"expanded hook Core/active\.asm:1 at 0x258500 starts before "
+            r"editor-managed range 0x258450-0x25E000 ends in the same "
+            r"physical LoROM bank",
+        ):
+            generate_manifest(self.fixture.root, dev_rom_path=rom_path)
+
+    def test_expanded_hook_just_before_editor_range_fails_closed(self) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm", 'incsrc "Core/active.asm"\n'
+        )
+        self.fixture.write_text(
+            "Core/active.asm",
+            "org $258448\n"
+            "JSL BoundaryStraddlingHook\n",
+        )
+        rom_path = self.fixture.write_dev_rom()
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            r"expanded hook Core/active\.asm:1 at 0x258448 starts before "
+            r"editor-managed range 0x258450-0x25E000 ends in the same "
+            r"physical LoROM bank",
+        ):
+            generate_manifest(self.fixture.root, dev_rom_path=rom_path)
+
+    def test_expanded_hook_at_editor_range_end_is_allowed(self) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm", 'incsrc "Core/active.asm"\n'
+        )
+        self.fixture.write_text(
+            "Core/active.asm",
+            "org $25E000\n"
+            "JSL WaterFillHook\n",
+        )
+        rom_path = self.fixture.write_dev_rom()
+
+        manifest = generate_manifest(
+            self.fixture.root, dev_rom_path=rom_path
+        )
+
+        self.assertEqual(manifest["summary"]["total_hooks"], 1)
+
+    def test_computed_local_define_orgs_cannot_bypass_editor_guard(self) -> None:
+        expressions = {
+            "direct_define": "!addr = $258448\norg !addr\n",
+            "define_arithmetic": "!base = $258440\norg !base+$08\n",
+        }
+        for name, source in expressions.items():
+            with self.subTest(name=name):
+                self.fixture.write_text(
+                    "Oracle_main.asm", 'incsrc "Core/active.asm"\n'
+                )
+                self.fixture.write_text(
+                    "Core/active.asm", source + "JSL ComputedHook\n"
+                )
+                rom_path = self.fixture.write_dev_rom()
+
+                hooks = scan_hooks(
+                    self.fixture.root,
+                    collect_reachable_asm_sources(self.fixture.root),
+                )
+                self.assertEqual([hook.address for hook in hooks], [0x258448])
+                with self.assertRaisesRegex(
+                    ManifestGenerationError,
+                    r"expanded hook Core/active\.asm:2 at 0x258448 starts "
+                    r"before editor-managed range 0x258450-0x25E000",
+                ):
+                    generate_manifest(
+                        self.fixture.root, dev_rom_path=rom_path
+                    )
+
+    def test_full_define_rhs_is_evaluated_before_org_guard(self) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm", 'incsrc "Core/active.asm"\n'
+        )
+        self.fixture.write_text(
+            "Core/active.asm",
+            "!addr = $248450+$010000\n"
+            "org !addr\n"
+            "JSL ComputedHook\n",
+        )
+        rom_path = self.fixture.write_dev_rom()
+
+        hooks = scan_hooks(
+            self.fixture.root,
+            collect_reachable_asm_sources(self.fixture.root),
+        )
+        self.assertEqual([hook.address for hook in hooks], [0x258450])
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            r"expanded hook Core/active\.asm:2 at 0x258450 starts before",
+        ):
+            generate_manifest(self.fixture.root, dev_rom_path=rom_path)
+
+    def test_unresolved_active_org_requires_source_bank_proof(self) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm", 'incsrc "Core/active.asm"\n'
+        )
+        self.fixture.write_text(
+            "Core/active.asm",
+            "org UnknownDestination\n"
+            "db $00\n",
+        )
+        rom_path = self.fixture.write_dev_rom()
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            r"Core/active\.asm:1: unresolved active org expression "
+            r"'UnknownDestination' has no @manifest-org-bank proof",
+        ):
+            generate_manifest(self.fixture.root, dev_rom_path=rom_path)
+
+    def test_unresolved_org_proof_must_avoid_editor_banks(self) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm", 'incsrc "Core/active.asm"\n'
+        )
+        self.fixture.write_text(
+            "Core/active.asm",
+            "org UnknownDestination ; @manifest-org-bank=$25\n"
+            "db $00\n",
+        )
+        rom_path = self.fixture.write_dev_rom()
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            r"unresolved active org expression 'UnknownDestination' may "
+            r"affect editor-managed physical LoROM bank 0x25",
+        ):
+            generate_manifest(self.fixture.root, dev_rom_path=rom_path)
+
+    def test_unresolved_org_proof_must_match_literal_bank_anchor(self) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm", 'incsrc "Core/active.asm"\n'
+        )
+        self.fixture.write_text(
+            "Core/active.asm",
+            "org $258448+!unknown ; @manifest-org-bank=$0D\n"
+            "db $00\n",
+        )
+        rom_path = self.fixture.write_dev_rom()
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            r"address-literal bank anchor\(s\) 0x25, contradicting "
+            r"@manifest-org-bank proof 0x0D",
+        ):
+            generate_manifest(self.fixture.root, dev_rom_path=rom_path)
+
+    def test_unresolved_org_proof_must_match_known_define_bank_anchor(
+        self,
+    ) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm", 'incsrc "Core/active.asm"\n'
+        )
+        self.fixture.write_text(
+            "Core/active.asm",
+            "!base = $258448\n"
+            "org !base+!unknown ; @manifest-org-bank=$0D\n"
+            "db $00\n",
+        )
+        rom_path = self.fixture.write_dev_rom()
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            r"address-literal bank anchor\(s\) 0x25, contradicting "
+            r"@manifest-org-bank proof 0x0D",
+        ):
+            generate_manifest(self.fixture.root, dev_rom_path=rom_path)
+
+    def test_unrecognized_unresolved_org_is_rejected_despite_disjoint_proof(
+        self,
+    ) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm", 'incsrc "Core/active.asm"\n'
+        )
+        self.fixture.write_text(
+            "Core/active.asm",
+            "org DynamicVanillaAddress ; @manifest-org-bank=$0E\n"
+            "db $00\n",
+        )
+        rom_path = self.fixture.write_dev_rom()
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            r"unresolved active org expression 'DynamicVanillaAddress' is "
+            r"not an audited source/expression/bank contract",
+        ):
+            generate_manifest(self.fixture.root, dev_rom_path=rom_path)
+
+    def test_invoked_unresolved_macro_org_requires_proof(self) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm", 'incsrc "Core/active.asm"\n'
+        )
+        self.fixture.write_text(
+            "Core/active.asm",
+            "macro WriteAt(addr)\n"
+            "  org <addr>\n"
+            "  db $00\n"
+            "endmacro\n"
+            "%WriteAt($258448)\n",
+        )
+        rom_path = self.fixture.write_dev_rom()
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            r"Core/active\.asm:2: unresolved active org expression '<addr>' "
+            r"has no @manifest-org-bank proof",
+        ):
+            generate_manifest(self.fixture.root, dev_rom_path=rom_path)
+
+    def test_invoked_macro_placeholder_rejects_single_bank_proof(self) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm", 'incsrc "Core/active.asm"\n'
+        )
+        self.fixture.write_text(
+            "Core/active.asm",
+            "!unknown = $08\n"
+            "macro WriteAt(offset)\n"
+            "  org <offset>+!unknown ; @manifest-org-bank=$0D\n"
+            "  db $00\n"
+            "endmacro\n"
+            "%WriteAt($258448)\n",
+        )
+        rom_path = self.fixture.write_dev_rom()
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            r"Core/active\.asm:3: unresolved active org expression "
+            r"'<offset>\+!unknown' contains a macro placeholder; a single "
+            r"@manifest-org-bank proof cannot cover every invocation",
+        ):
+            generate_manifest(self.fixture.root, dev_rom_path=rom_path)
+
+    def test_variadic_macro_placeholder_rejects_single_bank_proof(self) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm", 'incsrc "Core/active.asm"\n'
+        )
+        self.fixture.write_text(
+            "Core/active.asm",
+            "macro WriteAt(...)\n"
+            "  org <...[0]> ; @manifest-org-bank=$0D\n"
+            "  db $00\n"
+            "endmacro\n"
+            "%WriteAt($258448)\n",
+        )
+        rom_path = self.fixture.write_dev_rom()
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            r"unresolved active org expression '<\.\.\.\[0\]>' contains "
+            r"a macro placeholder",
+        ):
+            generate_manifest(self.fixture.root, dev_rom_path=rom_path)
+
+    def test_unsupported_asar_read_cannot_claim_literal_bank_proof(self) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm", 'incsrc "Core/active.asm"\n'
+        )
+        self.fixture.write_text(
+            "Core/active.asm",
+            "org read3($0D8000) ; @manifest-org-bank=$0D\n"
+            "db $00\n",
+        )
+        rom_path = self.fixture.write_dev_rom()
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            r"unresolved active org expression 'read3\(\$0D8000\)' is not "
+            r"an audited source/expression/bank contract",
+        ):
+            generate_manifest(self.fixture.root, dev_rom_path=rom_path)
+
+    def test_cross_file_define_cannot_claim_unverified_bank_proof(self) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm",
+            'incsrc "Core/defs.asm"\nincsrc "Core/active.asm"\n',
+        )
+        self.fixture.write_text("Core/defs.asm", "!base = $258448\n")
+        self.fixture.write_text(
+            "Core/active.asm",
+            "org !base+$08 ; @manifest-org-bank=$0D\n"
+            "db $00\n",
+        )
+        rom_path = self.fixture.write_dev_rom()
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            r"Core/active\.asm:1: unresolved active org expression "
+            r"'!base\+\$08' is not an audited source/expression/bank contract",
+        ):
+            generate_manifest(self.fixture.root, dev_rom_path=rom_path)
+
+    def test_unknown_macro_condition_scans_every_possible_org_branch(
+        self,
+    ) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm", 'incsrc "Core/active.asm"\n'
+        )
+        self.fixture.write_text(
+            "Core/active.asm",
+            "macro WriteAt(addr)\n"
+            "  if <addr> == $258448\n"
+            "    org $0E9000\n"
+            "    db $00\n"
+            "  else\n"
+            "    org $258448\n"
+            "    db $00\n"
+            "  endif\n"
+            "endmacro\n"
+            "%WriteAt($000000)\n",
+        )
+        rom_path = self.fixture.write_dev_rom()
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            r"expanded hook Core/active\.asm:6 at 0x258448 starts before",
+        ):
+            generate_manifest(self.fixture.root, dev_rom_path=rom_path)
+
+    def test_unknown_macro_branches_merge_only_identical_define_states(
+        self,
+    ) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm", 'incsrc "Core/active.asm"\n'
+        )
+        self.fixture.write_text(
+            "Core/active.asm",
+            "macro WriteAt(addr)\n"
+            "  if <addr>\n"
+            "    !target = $258448\n"
+            "  else\n"
+            "    !target = $0E9000\n"
+            "  endif\n"
+            "  org !target\n"
+            "  db $00\n"
+            "endmacro\n"
+            "%WriteAt($000001)\n",
+        )
+        rom_path = self.fixture.write_dev_rom()
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            r"Core/active\.asm:7: unresolved active org expression "
+            r"'!target' has no @manifest-org-bank proof",
+        ):
+            generate_manifest(self.fixture.root, dev_rom_path=rom_path)
+
+    def test_uninvoked_literal_macro_does_not_create_hook(self) -> None:
+        self.fixture.write_text(
+            "Oracle_main.asm", 'incsrc "Core/active.asm"\n'
+        )
+        self.fixture.write_text(
+            "Core/active.asm",
+            "macro NeverCalled()\n"
+            "  org $258448\n"
+            "  db $00\n"
+            "endmacro\n"
+            "org $0E9000\n"
+            "db $00\n",
+        )
+        rom_path = self.fixture.write_dev_rom()
+
+        manifest = generate_manifest(
+            self.fixture.root, dev_rom_path=rom_path
+        )
+
+        self.assertEqual(manifest["summary"]["total_hooks"], 1)
+
+    def test_literal_overworld_incsrc_remains_reachable_despite_flag(
         self,
     ) -> None:
         self.fixture.write_text(
@@ -352,9 +969,9 @@ class ReachableSourceTest(unittest.TestCase):
             entry["bank"] for entry in manifest["owned_banks"]["banks"]
         }
 
-        self.assertEqual(manifest["summary"]["total_hooks"], 1)
-        self.assertEqual(owned_banks, {"0x2E"})
-        self.assertEqual(manifest["room_tags"]["tags"], [])
+        self.assertEqual(manifest["summary"]["total_hooks"], 4)
+        self.assertEqual(owned_banks, {"0x2E", "0x40"})
+        self.assertEqual(len(manifest["room_tags"]["tags"]), 1)
 
 
 class RepositorySourceRegressionTest(unittest.TestCase):
@@ -508,8 +1125,10 @@ class DevRomProvenanceTest(unittest.TestCase):
         self.assertEqual(
             manifest["editor_managed_regions"]["regions"],
             [
-                {"start": "0x238280", "end": "0x2392B0"},
                 {"start": "0x07F61D", "end": "0x07F86D"},
+                {"start": "0x238280", "end": "0x2392B0"},
+                {"start": "0x258090", "end": "0x258408"},
+                {"start": "0x258450", "end": "0x25E000"},
             ],
         )
 
@@ -595,6 +1214,133 @@ class DevRomProvenanceTest(unittest.TestCase):
         self.assertEqual(manifest["rom"]["path"], "Roms/oos169x.sfc")
 
 
+class DungeonStreamRegionsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fixture = ManifestFixture()
+        self.fixture.write_text("Oracle_main.asm", "")
+
+    def tearDown(self) -> None:
+        self.fixture.close()
+
+    def test_manifest_emits_exact_live_dungeon_layout(self) -> None:
+        rom_path = self.fixture.write_dev_rom()
+
+        manifest = generate_manifest(
+            self.fixture.root,
+            dev_rom_path=rom_path,
+        )
+
+        self.assertEqual(
+            manifest["dungeon_stream_regions"],
+            {
+                "objects": {
+                    "pointer_table": "0x1F8000",
+                    "pointer_count": DUNGEON_ROOM_COUNT,
+                    "pointer_encoding": "long24",
+                    "strategy": "copy_on_write",
+                    "data_regions": [
+                        {"start": "0x0A8000", "end": "0x0AB730"},
+                        {"start": "0x1F878A", "end": "0x208000"},
+                        {"start": "0x03EB90", "end": "0x048000"},
+                        {"start": "0x278000", "end": "0x288000"},
+                        {"start": "0x298000", "end": "0x2A8000"},
+                    ],
+                    "allocation_regions": [{"start": "0x298000", "end": "0x2A8000"}],
+                },
+                "sprites": {
+                    "pointer_table": "0x09D2B2",
+                    "pointer_count": DUNGEON_ROOM_COUNT,
+                    "pointer_encoding": "bank16",
+                    "pointer_bank": "0x09",
+                    "strategy": "copy_on_write",
+                    "data_regions": [{"start": "0x09D502", "end": "0x09EC9F"}],
+                    "allocation_regions": [{"start": "0x09D502", "end": "0x09EC9F"}],
+                },
+                "pot_items": {
+                    "pointer_table": "0x01DB69",
+                    "pointer_count": DUNGEON_ROOM_COUNT,
+                    "pointer_encoding": "bank16",
+                    "pointer_bank": "0x01",
+                    "strategy": "repack_all",
+                    "data_regions": [{"start": "0x01DDE7", "end": "0x01E6B2"}],
+                    "allocation_regions": [{"start": "0x01DDE7", "end": "0x01E6B2"}],
+                },
+            },
+        )
+
+    def test_invalid_live_stream_pointers_fail_closed(self) -> None:
+        mutations = {
+            "object": (
+                0xF8000,
+                _pc_to_snes(0x60000),
+                3,
+                "object pointer for room 0x000",
+            ),
+            "sprite": (
+                0x4D2B2,
+                0xD501,
+                2,
+                "minimum sprite pointer",
+            ),
+            "pot": (
+                POT_POINTER_TABLE_PC,
+                0x7000,
+                2,
+                "pot-item pointer for room 0x000 is unmapped",
+            ),
+            "pot_below_fixed_floor": (
+                POT_POINTER_TABLE_PC,
+                0xDDBD,
+                2,
+                "pot-item pointer for room 0x000.*outside pot-item data region",
+            ),
+        }
+        for name, (target_pc, replacement, size, expected) in mutations.items():
+            with self.subTest(name=name):
+                rom_path = self.fixture.write_dev_rom()
+                self.fixture.write_rom_value(
+                    rom_path,
+                    target_pc,
+                    replacement,
+                    size,
+                )
+                with self.assertRaisesRegex(ManifestGenerationError, expected):
+                    derive_dungeon_stream_regions(rom_path)
+
+    def test_streams_must_terminate_before_region_or_bank_end(self) -> None:
+        mutations = {
+            "object": (
+                0xF8000,
+                _pc_to_snes(OBJECT_DATA_REGIONS_PC[0][1] - 1),
+                3,
+                "objects stream for room 0x000 is missing its two-byte header",
+            ),
+            "sprite": (
+                0x4D2B2,
+                _pc_to_snes(SPRITE_DATA_END_PC - 1) & 0xFFFF,
+                2,
+                "sprites stream for room 0x000 has no 0xFF terminator",
+            ),
+            "pot": (
+                POT_POINTER_TABLE_PC,
+                _pc_to_snes(POT_DATA_END_PC - 1) & 0xFFFF,
+                2,
+                "pot_items stream for room 0x000 has no 0xFFFF terminator",
+            ),
+        }
+        for name, (target_pc, replacement, size, expected) in mutations.items():
+            with self.subTest(name=name):
+                rom_path = self.fixture.write_dev_rom()
+                self.fixture.write_rom_value(
+                    rom_path,
+                    target_pc,
+                    replacement,
+                    size,
+                )
+                with self.assertRaisesRegex(ManifestGenerationError, expected):
+                    derive_dungeon_stream_regions(rom_path)
+
+
 class EditorManagedRegionsTest(unittest.TestCase):
     def setUp(self) -> None:
         self.fixture = ManifestFixture()
@@ -603,7 +1349,7 @@ class EditorManagedRegionsTest(unittest.TestCase):
     def tearDown(self) -> None:
         self.fixture.close()
 
-    def test_derives_exact_room_header_and_message_ranges(self) -> None:
+    def test_derives_exact_editor_managed_ranges(self) -> None:
         rom_path = self.fixture.write_dev_rom()
 
         regions = derive_editor_managed_regions(rom_path)
@@ -611,8 +1357,10 @@ class EditorManagedRegionsTest(unittest.TestCase):
         self.assertEqual(
             regions,
             [
-                {"start": "0x228280", "end": "0x2292B0"},
                 {"start": "0x07F61D", "end": "0x07F86D"},
+                {"start": "0x228280", "end": "0x2292B0"},
+                {"start": "0x258090", "end": "0x258408"},
+                {"start": "0x258450", "end": "0x25E000"},
             ],
         )
 
@@ -628,8 +1376,10 @@ class EditorManagedRegionsTest(unittest.TestCase):
         self.assertEqual(
             manifest["editor_managed_regions"]["regions"],
             [
-                {"start": "0x228280", "end": "0x2292B0"},
                 {"start": "0x07F61D", "end": "0x07F86D"},
+                {"start": "0x228280", "end": "0x2292B0"},
+                {"start": "0x258090", "end": "0x258408"},
+                {"start": "0x258450", "end": "0x25E000"},
             ],
         )
 
@@ -641,6 +1391,70 @@ class EditorManagedRegionsTest(unittest.TestCase):
             "Room-header pointers are not unique",
         ):
             derive_editor_managed_regions(rom_path)
+
+    def test_custom_collision_pointer_into_water_fill_tail_fails_closed(
+        self,
+    ) -> None:
+        rom_path = self.fixture.write_dev_rom()
+        self.fixture.write_rom_value(
+            rom_path,
+            CUSTOM_COLLISION_POINTER_TABLE_PC,
+            _pc_to_snes(CUSTOM_COLLISION_DATA_END_PC),
+            3,
+        )
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            "custom-collision pointer for room 0x000.*outside the "
+            "editor-owned region",
+        ):
+            derive_editor_managed_regions(rom_path)
+
+    def test_custom_collision_stream_cannot_cross_water_fill_tail(self) -> None:
+        rom_path = self.fixture.write_dev_rom()
+        self.fixture.write_rom_value(
+            rom_path,
+            CUSTOM_COLLISION_POINTER_TABLE_PC,
+            _pc_to_snes(CUSTOM_COLLISION_DATA_END_PC - 1),
+            3,
+        )
+        data = bytearray(rom_path.read_bytes())
+        data[CUSTOM_COLLISION_DATA_END_PC - 1] = 0xFF
+        rom_path.write_bytes(data)
+
+        with self.assertRaisesRegex(
+            ManifestGenerationError,
+            "crosses reserved WaterFill data",
+        ):
+            derive_editor_managed_regions(rom_path)
+
+    def test_custom_collision_geometry_must_fit_64x64_map(self) -> None:
+        malformed_streams = {
+            "zero_dimension": (
+                b"\x00\x00\x00\x01\xFF\xFF",
+                "zero dimension 0x1",
+            ),
+            "single_offset_0x1000": (
+                b"\xF0\xF0\x00\x10\x07\xFF\xFF",
+                "single-tile offset 0x1000.*outside the 64x64 map",
+            ),
+            "rectangle_crosses_right_edge": (
+                b"\xFF\x0F\x02\x01\x01\x02\xFF\xFF",
+                "offset 0x0FFF with size 2x1 exceeds the 64x64 map",
+            ),
+        }
+        for name, (stream, expected) in malformed_streams.items():
+            with self.subTest(name=name):
+                rom_path = self.fixture.write_dev_rom()
+                data = bytearray(rom_path.read_bytes())
+                end = CUSTOM_COLLISION_DATA_START_PC + len(stream)
+                data[CUSTOM_COLLISION_DATA_START_PC:end] = stream
+                rom_path.write_bytes(data)
+
+                with self.assertRaisesRegex(
+                    ManifestGenerationError, expected
+                ):
+                    derive_editor_managed_regions(rom_path)
 
     def test_low_half_header_table_pointer_fails_closed(self) -> None:
         rom_path = self.fixture.write_dev_rom()

--- a/Scripts/Generate/validate_custom_collision_source.py
+++ b/Scripts/Generate/validate_custom_collision_source.py
@@ -16,7 +16,9 @@ from typing import Any
 SOURCE_PATH = Path("Data/dungeons/custom_collision.json")
 
 NUMBER_OF_ROOMS = 296
-COLLISION_MAP_TILES = 64 * 64
+COLLISION_MAP_WIDTH = 64
+COLLISION_MAP_HEIGHT = 64
+COLLISION_MAP_TILES = COLLISION_MAP_WIDTH * COLLISION_MAP_HEIGHT
 POINTER_TABLE_START = 0x128090
 COLLISION_DATA_START = 0x128450
 COLLISION_DATA_END_EXCLUSIVE = 0x12E000
@@ -169,10 +171,32 @@ def _load_source(source_path: Path) -> tuple[CollisionRooms, bytes, str]:
     return rooms, source_bytes, source_sha256
 
 
-def _snes_to_pc(address: int) -> int:
-    if address >= 0x808000:
-        address -= 0x808000
-    return (address & 0x7FFF) + ((address // 2) & 0xFF8000)
+def _strict_lorom_to_pc(address: int, room_id: int) -> int:
+    """Convert a raw ROM pointer only when it is mapped, ROM-backed LoROM."""
+    if not 0 <= address <= 0xFFFFFF:
+        raise CustomCollisionSourceContractError(
+            f"ROM room 0x{room_id:02X} collision pointer 0x{address:X} is "
+            "outside 24-bit address space"
+        )
+    bank = (address >> 16) & 0xFF
+    offset = address & 0xFFFF
+    if bank in (0x7E, 0x7F, 0xFE, 0xFF):
+        raise CustomCollisionSourceContractError(
+            f"ROM room 0x{room_id:02X} collision pointer 0x{address:06X} "
+            f"uses WRAM bank or mirror 0x{bank:02X}"
+        )
+    if offset < 0x8000:
+        raise CustomCollisionSourceContractError(
+            f"ROM room 0x{room_id:02X} collision pointer 0x{address:06X} "
+            "is a raw low-half LoROM address"
+        )
+    pc_address = ((bank & 0x7F) << 15) | (offset & 0x7FFF)
+    if pc_address >= 0x3F0000:
+        raise CustomCollisionSourceContractError(
+            f"ROM room 0x{room_id:02X} collision pointer 0x{address:06X} "
+            "maps into the WRAM-backed LoROM PC window"
+        )
+    return pc_address
 
 
 def _read_u16(data: bytes, offset: int) -> int:
@@ -180,7 +204,7 @@ def _read_u16(data: bytes, offset: int) -> int:
 
 
 def _decode_room(data: bytes, room_id: int, snes_pointer: int) -> dict[int, int]:
-    cursor = _snes_to_pc(snes_pointer)
+    cursor = _strict_lorom_to_pc(snes_pointer, room_id)
     if not COLLISION_DATA_START <= cursor < COLLISION_DATA_END_EXCLUSIVE:
         raise CustomCollisionSourceContractError(
             f"ROM room 0x{room_id:02X} collision pointer "
@@ -220,7 +244,10 @@ def _decode_room(data: bytes, room_id: int, snes_pointer: int) -> dict[int, int]
         height = data[cursor + 1]
         cursor += 2
         if width == 0 or height == 0:
-            continue
+            raise CustomCollisionSourceContractError(
+                f"ROM room 0x{room_id:02X} has zero-dimension collision "
+                f"rectangle {width}x{height}"
+            )
 
         byte_count = width * height
         if cursor + byte_count > COLLISION_DATA_END_EXCLUSIVE:
@@ -228,14 +255,18 @@ def _decode_room(data: bytes, room_id: int, snes_pointer: int) -> dict[int, int]
                 f"ROM room 0x{room_id:02X} rectangle crosses the collision "
                 "data boundary"
             )
-        last_offset = offset + ((height - 1) * 64) + (width - 1)
-        if offset >= COLLISION_MAP_TILES or last_offset >= COLLISION_MAP_TILES:
+        start_row, start_column = divmod(offset, COLLISION_MAP_WIDTH)
+        if (
+            offset >= COLLISION_MAP_TILES
+            or start_column + width > COLLISION_MAP_WIDTH
+            or start_row + height > COLLISION_MAP_HEIGHT
+        ):
             raise CustomCollisionSourceContractError(
                 f"ROM room 0x{room_id:02X} has an out-of-range collision "
-                "rectangle"
+                f"rectangle at offset {offset} with size {width}x{height}"
             )
         for row in range(height):
-            row_offset = offset + (row * 64)
+            row_offset = offset + (row * COLLISION_MAP_WIDTH)
             for column in range(width):
                 tiles[row_offset + column] = data[cursor]
                 cursor += 1


### PR DESCRIPTION
## What

- update `Oracle-of-Secrets.yaze` to the synchronized editable-ROM SHA-1 (`58c9fadc6228d3d78d6baa7b7cc1c31cf57ed196`)
- derive and emit fail-closed dungeon object, sprite, and pot-item stream contracts for all 296 rooms
- derive exact editor-managed room-header, message-ID, and custom-collision ranges while keeping the `$25:E000+` WaterFill tail ASM-owned
- reject malformed streams, collision geometry, low-half LoROM pointers, WRAM mirrors, and ROM addresses outside the ROM-backed LoROM window
- validate expanded/computed `org` writes against editor-owned ranges, including conservative conditional reachability and 13 exact audited unresolved-org contracts backed by Asar assertions
- make literal `incsrc` reachability authoritative and reject cross-file reassignment of preloaded globals instead of guessing include-order state
- preserve the maximum protected span when conditional hook alternatives share an address

## Why

The D6 save/reopen qualification needs the editor and Oracle build to agree on exactly which dungeon bytes Yaze may rewrite. Missing or stale stream/allocation metadata could otherwise turn a successful save into silent corruption or an Asar overwrite on the next build.

## Verification

- `python3 Scripts/Generate/tests/test_generate_hack_manifest.py` — 59/59 passed
- `python3 Scripts/Generate/tests/test_custom_collision_source_contract.py` — 20/20 passed
- Yaze real-OoS `DungeonPotRepackOosIntegrationTest.*` — 11/11 passed
- Yaze project bundle verification — 7/7 passed, zero warnings
- `./Scripts/Build/build_rom.sh 168 --skip-tests` — passed through source validators, Asar, manifest generation, symbols, and ZScream overlap check
- generated manifest is deterministic and byte-identical across rebuilds:
  - SHA-256 `93c3b42e5b0e1e04701ca459705f256d340fb7a047dbbeb3fadba926bc96cc82`
  - 545 hooks / 390 protected regions / 24 owned banks / 109 messages
- editable ROM remained unchanged:
  - SHA-1 `58c9fadc6228d3d78d6baa7b7cc1c31cf57ed196`
  - SHA-256 `b13ef69ede313756dcf560bf0f993663d68d0365609f2c20dcdec2c17f31f7b9`
- rebuilt patched ROM SHA-256 `fc8590bd382c25ce5c4ad56f08000ad0641768a6090be295e1201e3bcc3664f9`
- `git diff --check` — clean

## Safety / scope

- no tracked ROM artifacts
- no workflow or build-script changes
- branch is based directly on current `origin/master` (`a9a53d71782566e0c125b5286b15df57643a0ed7`)
- PR #107 is still independently open/conflicting; this PR does not depend on it and has no file overlap with its current changed-file list
- emulator smoke was intentionally not claimed here; the next gate is the disposable D6 GUI save/reopen/build/Mesen qualification
