### PR TITLE
Disable WaterFill saves in the Oracle project

### DIFF
--- a/Oracle-of-Secrets.yaze
+++ b/Oracle-of-Secrets.yaze
@@ -38,6 +38,7 @@ write_policy=block
 load_custom_overworld=true
 apply_zs_custom_overworld_asm=true
 save_dungeon_maps=false
+save_dungeon_water_fill_zones=false
 save_graphics_sheet=false
 enable_custom_objects=true
 


### PR DESCRIPTION
## Summary

- disable the WaterFill save domain in the canonical Oracle project descriptor
- keep Oracle's authored WaterFill data fail-closed until the project explicitly opts in and reopens
- align the project with Yaze #202's fixed-at-open save-scope contract

## Verification

- exact head: `7f4171ba4f1b44cb7ec99016732e7f65149d3680`
- diff: exactly one insertion in `Oracle-of-Secrets.yaze`
- `expected_hash` preserved as `58c9fadc6228d3d78d6baa7b7cc1c31cf57ed196`
- `ProjectPathsTest.WaterFillSaveScopeRoundTripsThroughIni`: 1/1 passed
- `z3ed project-bundle-verify --check-rom-hash --format=json`: 7 passed, 0 warnings, 0 failures
- verification report SHA-256: `d6cd44e5b5283fb857754f390e55011665bd314a82f13eb0db87720382a0a9bd`

No canonical ROM was modified. No workflow files are changed.
